### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository_owner == "zliel"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Install cargo-release
-        run: cargo install cargo-release
-
       - name: Publish to crates.io
-        run: cargo release --publish --no-confirm minor
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on:
   push:
-    branches: ["main"]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I reverted back to using `cargo publish` instead of `cargo-release`, and changed to using Tag commits to determine when to run this workflow.

## More Details

<!-- Describe the changes made in this pull request -->

- Tag commits in the form of `v[0-9]+.[0-9]+.[0-9]+` will trigger the publish workflow
- The workflow now only publishes the crate if it's being run in this repository
- The workflow uses `cargo publish --locked` instead of `cargo-release`