### PR TITLE
Update readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,20 +3,6 @@
 version = 4
 
 [[package]]
-name = "Mark-rs"
-version = "1.0.1"
-dependencies = [
- "clap",
- "dirs",
- "env_logger",
- "log",
- "serde",
- "toml",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +253,20 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mark-rs"
+version = "1.0.0"
+dependencies = [
+ "clap",
+ "dirs",
+ "env_logger",
+ "log",
+ "serde",
+ "toml",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "A Markdown parser and Static Site Generator"
 edition = "2024"
-name = "Mark-rs"
+name = "mark-rs"
 version = "1.0.1"
 license = "MIT OR Apache-2.0"
 keywords = ["markdown", "cli", "ssg", "static_site", "notes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "A Markdown parser and Static Site Generator"
 edition = "2024"
 name = "mark-rs"
-version = "1.0.1"
+version = "1.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["markdown", "cli", "ssg", "static_site", "notes"]
 repository = "https://github.com/zliel/Mark-rs"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/zliel/Mark-rs/actions/workflows/CI.yml/badge.svg)](https://github.com/zliel/Mark-rs/actions/workflows/CI.yml)
 [![Publish](https://github.com/zliel/Mark-rs/actions/workflows/publish.yml/badge.svg)](https://github.com/zliel/Mark-rs/actions/workflows/publish.yml)
-[![Crates.io Version](https://img.shields.io/crates/v/Mark-rs)](https://crates.io/crates/Mark-rs)
+[![Crates.io Version](https://img.shields.io/crates/v/mark-rs)](https://crates.io/crates/mark-rs)
 
 Mark-rs is a 100% Commonmark-compliant Markdown parser and static site generator written in Rust.
 It is designed to be fast, efficient, and easy to use.
@@ -48,8 +48,18 @@ To install Mark-rs, you need to have Rust installed on your system. You can inst
 Once you have Rust installed, you can install Mark-rs using Cargo:
 
 ```bash
-cargo install Mark-rs
+cargo install mark-rs
 ```
+
+**Note**: Make sure to have the `~/.cargo/bin` directory in your `PATH` environment variable so you can run the `markrs` command from anywhere.
+
+If it isn't already in your `PATH`, you can adding the following line to your shell configuration file (e.g., `~/.bashrc`, `~/.zshrc`, etc.):
+
+```bash:
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+On Windows, you can add the `C:\Users\your_user\.cargo\bin` directory to your `PATH` environment variable.
 
 ## Usage
 
@@ -78,11 +88,11 @@ You can customize Mark-rs's behavior by specifying a config file to use. If a co
 
 The default configuration directories (defined by the [`dirs` crate](https://docs.rs/dirs/latest/dirs/) ) are:
 
-| Platform | Value                                 | Example                                         |
-| -------- | ------------------------------------- | ----------------------------------------------- |
-| Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config/markrs                      |
-| macOS    | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support/markrs |
-| Windows  | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming\markrs           |
+| Platform | Value                                 | Example                                             |
+| -------- | ------------------------------------- | --------------------------------------------------- |
+| Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/your_user/.config/markrs                      |
+| macOS    | `$HOME`/Library/Application Support   | /Users/your_user/Library/Application Support/markrs |
+| Windows  | `{FOLDERID_RoamingAppData}`           | C:\Users\your_user\AppData\Roaming\markrs           |
 
 Here is the default configuration:
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,20 @@ The following HTML page will be generated:
 ## Installation (WIP)
 
 To install Mark-rs, you need to have Rust installed on your system. You can install Rust using [rustup](https://rustup.rs/).
+
+### Install via Cargo
+
 Once you have Rust installed, you can install Mark-rs using Cargo:
 
 ```bash
 cargo install mark-rs
 ```
+
+### Install via Pre-built Binaries
+
+You can also download pre-built binaries for your platform from the [releases page](https://github.com/zliel/Mark-rs/releases)
+
+From there, you can download the appropriate binary for your operating system and architecture, extract it, and use it directly.
 
 **Note**: Make sure to have the `~/.cargo/bin` directory in your `PATH` environment variable so you can run the `markrs` command from anywhere.
 


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I updated the readme to reflect one more name change (from "Mark-rs" to "mark-rs" for ease of typing and consistency), and added instructions for installing both from cargo and the pre-built binary releases. I also reverted the version number back to 1.0.0 as the crates.io page will change