### PR TITLE
Add blockquote support

### DIFF
--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -307,12 +307,12 @@ pub fn generate_default_css() -> String {
 
     blockquote {
     border-left: 4px solid #555;
-    padding-left: 1rem;
+    padding: 0.1rem 1rem;
     color: #aaa;
     font-style: italic;
     margin: 1.5rem 0;
     background-color: #1a1a1a;
-    border-radius: 4px;
+    border-radius: 2px;
     }
 
     ul,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -111,6 +111,15 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 
                 tokens.push(Token::TableCellSeparator);
             }
+            ">" => {
+                push_buffer_to_collection(&mut tokens, &mut buffer);
+
+                if i == 0 {
+                    tokens.push(Token::BlockQuoteMarker);
+                } else {
+                    buffer.push_str(chars[i]);
+                }
+            }
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
                 // Check for valid ordered list marker
                 if i + 2 < str_len && chars[i + 1] == "." && chars[i + 2] == " " {

--- a/src/lexer/test.rs
+++ b/src/lexer/test.rs
@@ -267,6 +267,26 @@ fn tab_via_spaces() {
 }
 
 #[test]
+fn blockquote() {
+    init_test_config();
+    assert_eq!(
+        tokenize("> This is a blockquote."),
+        vec![
+            BlockQuoteMarker,
+            Whitespace,
+            Text(String::from("This")),
+            Whitespace,
+            Text(String::from("is")),
+            Whitespace,
+            Text(String::from("a")),
+            Whitespace,
+            Text(String::from("blockquote")),
+            Punctuation(String::from("."))
+        ]
+    );
+}
+
+#[test]
 fn unicode_mixed() {
     init_test_config();
     assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1009,6 +1009,14 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
             Some(Token::TableCellSeparator) => {
                 group_table_rows(&mut blocks, &mut current_block, &mut previous_block, line);
             }
+            Some(Token::Whitespace) => {
+                group_text_lines(
+                    &mut blocks,
+                    &mut current_block,
+                    &mut previous_block,
+                    &mut line[1..].to_vec(),
+                );
+            }
             _ => {
                 // Catch-all for everything else
                 current_block.extend(line.to_owned());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,8 +67,6 @@ fn parse_block(line: Vec<Token>) -> Option<MdBlockElement> {
 }
 
 fn parse_blockquote(line: Vec<Token>) -> MdBlockElement {
-    let mut content: Vec<MdBlockElement> = Vec::new();
-
     let lines_split_by_newline = line
         .split(|token| *token == Token::Newline)
         .collect::<Vec<_>>();
@@ -92,7 +90,7 @@ fn parse_blockquote(line: Vec<Token>) -> MdBlockElement {
 
     let grouped_inner_blocks = group_lines_to_blocks(inner_blocks);
 
-    content.extend(parse_blocks(grouped_inner_blocks));
+    let content = parse_blocks(grouped_inner_blocks);
 
     if content.is_empty() {
         MdBlockElement::Paragraph {

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1766,6 +1766,34 @@ mod html_generation {
         }
 
         #[test]
+        fn blockquote() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![tokenize(
+                    "> This is a blockquote."
+                )]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<blockquote><p>This is a blockquote.</p></blockquote>"
+            );
+        }
+
+        #[test]
+        fn blockquote_with_nested_block_element() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("> This is a blockquote with a nested heading:"),
+                    tokenize("> # Heading 1"),
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<blockquote><p>This is a blockquote with a nested heading:</p><h1>Heading 1</h1></blockquote>"
+            );
+        }
+
         #[test]
         fn table_all_left_align() {
             init_test_config();

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -903,6 +903,60 @@ mod block {
     }
 
     #[test]
+    fn blockquote() {
+        init_test_config();
+        assert_eq!(
+            parse_block(tokenize("> This is a blockquote.")),
+            Some(BlockQuote {
+                content: vec![Paragraph {
+                    content: vec![Text {
+                        content: String::from("This is a blockquote.")
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn blockquote_with_nested_block_elements() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("> This is a blockquote with a nested list:"),
+                tokenize("> - Item 1"),
+                tokenize("> - Item 2")
+            ])),
+            vec![BlockQuote {
+                content: vec![
+                    Paragraph {
+                        content: vec![Text {
+                            content: String::from("This is a blockquote with a nested list:")
+                        }]
+                    },
+                    UnorderedList {
+                        items: vec![
+                            MdListItem {
+                                content: Paragraph {
+                                    content: vec![Text {
+                                        content: String::from("Item 1")
+                                    }]
+                                }
+                            },
+                            MdListItem {
+                                content: Paragraph {
+                                    content: vec![Text {
+                                        content: String::from("Item 2")
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
     fn code_block() {
         init_test_config();
         assert_eq!(
@@ -1711,6 +1765,7 @@ mod html_generation {
             );
         }
 
+        #[test]
         #[test]
         fn table_all_left_align() {
             init_test_config();

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,7 @@ pub enum Token {
     Escape(String),
     Tab,
     Newline,
+    BlockQuoteMarker,
 }
 
 impl From<String> for Token {

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,6 +63,9 @@ pub enum MdBlockElement {
         headers: Vec<MdTableCell>,
         body: Vec<Vec<MdTableCell>>,
     },
+    BlockQuote {
+        content: Vec<MdBlockElement>,
+    },
 }
 
 impl ToHtml for MdBlockElement {
@@ -130,6 +133,13 @@ impl ToHtml for MdBlockElement {
                 format!(
                     "<table><thead><tr>{header_html}</tr></thead><tbody>{body_html}</tbody></table>"
                 )
+            }
+            MdBlockElement::BlockQuote { content } => {
+                let inner_html = content
+                    .iter()
+                    .map(|el| el.to_html(output_dir, input_dir, html_rel_path))
+                    .collect::<String>();
+                format!("<blockquote>{inner_html}</blockquote>")
             }
         }
     }


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for blockquotes

## More Details

<!-- Describe the changes made in this pull request -->

- There is now a new `Token::BlockQuoteMarker` variant
- There is now a new `MdBlockElement::BlockQuote` variant
  - It has a `content: Vec<MdBlockElement>` field
- Lines starting with whitespaces now explicitly get grouped as lines of text
  - **Note:** This does not affect properly formed block elements. This was a change added to handle blockquotes' 

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- There are tokenizing, parsing, and html generation tests for both single-line and multiline blockquotes, as well as blockquotes including inner block and inner elements

## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->
Given this input:
```md
## Quote With Inner Elements

> This quote has a block element inside it.
>
> # Located here
>
> And there's even some **bold text** inside it.
> And a [link](https://example.com) too.
> Not only that, but there's also a list:
>
> - Item 1
> - Item 2
>    - Nested Item 3

> And a code block:
>
> ```python
> def example_function():
>   print("This is a code block inside a quote.")
> ```

```

This page is generated:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bbd1853d-ae77-4d0e-b763-f7c4a36ec39a" />
