### PR TITLE
Add workflow for deploying docs

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,8 +1,8 @@
 name: Generate and Push Docs to GH Pages
-
 on:
   push:
     branches: ["main"]
+
 jobs:
   push_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,0 +1,23 @@
+name: Generate and Push Docs to GH Pages
+
+on:
+  push:
+    branches: ["main"]
+jobs:
+  push_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Generate Docs
+        run: cargo doc --no-deps
+
+      - name: Publish Docs
+        uses: crazy-max/ghaction-github-pages@v4
+        with:
+          target_branch: gh_pages
+          build_dir: target/doc
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added a workflow that generates docs and then deploys them to GitHub Pages

## More Details

<!-- Describe the changes made in this pull request -->

- There is now a `.github/workflows/generate_docs.yml` file that describes a workflow to checkout the code, generate docs, and then push them to GH Pages using [crazy-max/ghaction-github-pages@v4](https://github.com/crazy-max/ghaction-github-pages)
- This will run every time an update is pushed to main