### PR TITLE
Added a step for adding an index.html file that redirects to markrs index

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Generate Docs
         run: cargo doc --no-deps
 
+      - name: Insert Root index.html
+        run: echo '<meta http-equiv="refresh" content="0;url=markrs/index.html">' > target/doc/index.html
+
       - name: Publish Docs
         uses: crazy-max/ghaction-github-pages@v4
         with:


### PR DESCRIPTION
Minor update adding a step that will `echo` a `<meta>` tag that redirects to the `markrs/index.html` file. Running `cargo doc` puts the `index.html` file into a subdirectory, but GH Pages looks for an index in the root or `/docs` directory.

This comes basically directly from [this user's workflow](https://github.com/dnaka91/advent-of-code/blob/main/.github/workflows/docs.yml)