### PR TITLE
Add raw html support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is designed to be fast, efficient, and easy to use.
   - [Usage](#usage)
     - [Options](#options)
   - [Configuration](#configuration)
+  - [Note: Raw HTML](Note-raw-html)
   <!--toc:end-->
 
 ## Features
@@ -43,7 +44,7 @@ Here's a picture saying "Hello, World!":
 The following HTML page will be generated:
 ![Image of the generated HTML page with matching content](./media/example_screenshot.png)
 
-## Installation (WIP)
+## Installation
 
 To install Mark-rs, you need to have Rust installed on your system. You can install Rust using [rustup](https://rustup.rs/).
 
@@ -116,3 +117,9 @@ tab_size = 4
 css_file = "default" # "default" for the default styles
 favicon_file = ""    # Empty for no favicon
 ```
+
+## ⚠️Note: Raw HTML
+
+Mark-rs supports using raw HTML in input Markdown files, but it should be noted that using raw HTML can lead to security vulnerabilities, such as XSS (Cross-Site Scripting) attacks, if the input is not properly sanitized. Therefore, it is recommended to use raw HTML with caution and only when necessary.
+
+As of right now, Mark-rs does not sanitize raw HTML, so that users can use things like script tags and embedded content, but do so with caution. For more information on XSS attacks, see [OWASP](https://owasp.org/www-community/attacks/xss/) and the [OWASP XSS Prevention Cheat Sheet.](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is designed to be fast, efficient, and easy to use.
   - [Usage](#usage)
     - [Options](#options)
   - [Configuration](#configuration)
-  - [Note: Raw HTML](Note-raw-html)
+  - [Note: Raw HTML](note-raw-html)
   <!--toc:end-->
 
 ## Features

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -120,6 +120,24 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                     buffer.push_str(chars[i]);
                 }
             }
+            "<" => {
+                push_buffer_to_collection(&mut tokens, &mut buffer);
+
+                while i + 1 < str_len && chars[i + 1] != ">" {
+                    buffer.push_str(chars[i]);
+                    i += 1;
+                }
+
+                if i + 1 < str_len && chars[i + 1] == ">" {
+                    buffer.push_str(chars[i]);
+                    buffer.push_str(chars[i + 1]);
+                    tokens.push(Token::RawHtmlTag(buffer.clone()));
+                    buffer.clear();
+                    i += 1;
+                } else {
+                    buffer.push_str(chars[i]);
+                }
+            }
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
                 // Check for valid ordered list marker
                 if i + 2 < str_len && chars[i + 1] == "." && chars[i + 2] == " " {

--- a/src/lexer/test.rs
+++ b/src/lexer/test.rs
@@ -323,6 +323,44 @@ fn raw_inline_html() {
 }
 
 #[test]
+fn malformed_raw_html_no_closing_bracket() {
+    init_test_config();
+    assert_eq!(
+        tokenize("<div Missing bracket"),
+        vec![Text(String::from("<div Missing bracket")),]
+    );
+}
+
+#[test]
+fn malformed_raw_html_no_closing_tag() {
+    init_test_config();
+    assert_eq!(
+        tokenize("<div>Unclosed tag"),
+        vec![
+            RawHtmlTag(String::from("<div>")),
+            Text(String::from("Unclosed")),
+            Whitespace,
+            Text(String::from("tag"))
+        ]
+    );
+}
+
+#[test]
+fn malformed_raw_html_mismatched_tags() {
+    init_test_config();
+    assert_eq!(
+        tokenize("<div>Unmatched tags</span>"),
+        vec![
+            RawHtmlTag(String::from("<div>")),
+            Text(String::from("Unmatched")),
+            Whitespace,
+            Text(String::from("tags")),
+            RawHtmlTag(String::from("</span>"))
+        ]
+    );
+}
+
+#[test]
 fn unicode_mixed() {
     init_test_config();
     assert_eq!(

--- a/src/lexer/test.rs
+++ b/src/lexer/test.rs
@@ -287,6 +287,42 @@ fn blockquote() {
 }
 
 #[test]
+fn raw_html_basic() {
+    init_test_config();
+    assert_eq!(tokenize("<br>"), vec![RawHtmlTag(String::from("<br>"))]);
+}
+
+#[test]
+fn raw_html_with_attributes() {
+    init_test_config();
+    assert_eq!(
+        tokenize("<img src=\"image.jpg\" alt=\"An image\">"),
+        vec![RawHtmlTag(String::from(
+            "<img src=\"image.jpg\" alt=\"An image\">"
+        ))]
+    );
+}
+
+#[test]
+fn raw_inline_html() {
+    init_test_config();
+    assert_eq!(
+        tokenize("This is <span>Inline HTML</span>"),
+        vec![
+            Text(String::from("This")),
+            Whitespace,
+            Text(String::from("is")),
+            Whitespace,
+            RawHtmlTag(String::from("<span>")),
+            Text(String::from("Inline")),
+            Whitespace,
+            Text(String::from("HTML")),
+            RawHtmlTag(String::from("</span>"))
+        ]
+    );
+}
+
+#[test]
 fn unicode_mixed() {
     init_test_config();
     assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -521,6 +521,8 @@ pub fn parse_inline(markdown_tokens: Vec<Token>) -> Vec<MdInlineElement> {
             Token::CloseParenthesis => buffer.push(')'),
             Token::ThematicBreak => buffer.push_str("---"),
             Token::TableCellSeparator => buffer.push('|'),
+            Token::BlockQuoteMarker => buffer.push('>'),
+            Token::RawHtmlTag(tag_content) => buffer.push_str(tag_content.as_str()),
             _ => push_buffer_to_collection(&mut parsed_inline_elements, &mut buffer),
         }
 
@@ -568,6 +570,7 @@ fn parse_code_span(cursor: &mut TokenCursor) -> String {
             Token::Newline => code_content.push('\n'),
             Token::ThematicBreak => code_content.push_str("---"),
             Token::BlockQuoteMarker => code_content.push('>'),
+            Token::RawHtmlTag(tag_content) => code_content.push_str(tag_content),
             Token::CodeFence => {}
         }
 
@@ -703,6 +706,7 @@ where
                 Token::ThematicBreak => uri.push_str("---"),
                 Token::TableCellSeparator => uri.push('|'),
                 Token::BlockQuoteMarker => uri.push('>'),
+                Token::RawHtmlTag(tag_content) => uri.push_str(tag_content),
                 _ => {}
             }
         } else {
@@ -734,6 +738,12 @@ where
                 Token::CodeFence => title.push_str("```"),
                 Token::ThematicBreak => title.push_str("---"),
                 Token::BlockQuoteMarker => title.push('>'),
+                Token::RawHtmlTag(tag_content) => {
+                    warn!(
+                        "Raw HTML tags in titles can result in unexpected behavior: {tag_content}"
+                    );
+                    title.push_str(tag_content);
+                }
             }
         }
         cursor.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1193,6 +1193,12 @@ fn group_tabbed_lines(
                         blocks.pop();
                         blocks.push(previous_block.clone());
                     }
+                    Some(Token::RawHtmlTag(_)) => {
+                        previous_block.push(Token::Newline);
+                        previous_block.extend(line.to_owned());
+                        blocks.pop();
+                        blocks.push(previous_block.clone());
+                    }
                     _ => {
                         // If the previous block is not a list, then we just add the
                         // line to the current block

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1001,11 +1001,23 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
                 }
             }
             Some(Token::Text(string)) if string == "=" => {
+                let has_trailing_content = line.iter().skip(1).any(|token| match token {
+                    Token::Text(s) if s == "=" => false,
+                    Token::Whitespace | Token::Tab | Token::Newline => false,
+                    _ => true,
+                });
+
                 // Setext heading 1
                 if let Some(previous_line_start) = previous_block.first() {
-                    // If it's text, then prepend the previous line with "# "
-                    if matches!(previous_line_start, Token::Text(_)) {
+                    if !has_trailing_content && matches!(previous_line_start, Token::Text(_)) {
                         group_setext_heading_one(&mut blocks, &mut previous_block);
+                    } else {
+                        group_text_lines(
+                            &mut blocks,
+                            &mut current_block,
+                            &mut previous_block,
+                            line,
+                        );
                     }
                 } else {
                     current_block.extend(line.to_owned());

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -325,6 +325,39 @@ mod inline {
             }]
         );
     }
+
+    #[test]
+    fn malformed_raw_html_no_closing_bracket() {
+        init_test_config();
+        assert_eq!(
+            parse_inline(tokenize("<span Malformed HTML")),
+            vec![Text {
+                content: String::from("<span Malformed HTML")
+            }]
+        );
+    }
+
+    #[test]
+    fn malformed_raw_html_no_closing_tag() {
+        init_test_config();
+        assert_eq!(
+            parse_inline(tokenize("<span>Unclosed HTML")),
+            vec![Text {
+                content: String::from("<span>Unclosed HTML")
+            }]
+        );
+    }
+
+    #[test]
+    fn malformed_raw_html_mismatched_tags() {
+        init_test_config();
+        assert_eq!(
+            parse_inline(tokenize("<span>Unmatched </div> tags")),
+            vec![Text {
+                content: String::from("<span>Unmatched </div> tags")
+            }]
+        );
+    }
 }
 
 mod block {
@@ -1049,6 +1082,41 @@ mod block {
                         content: String::from(".")
                     }
                 ]
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_raw_html_no_closing_bracket() {
+        init_test_config();
+        assert_eq!(
+            parse_block(tokenize("<div Malformed HTML")),
+            Some(Paragraph {
+                content: vec![Text {
+                    content: String::from("<div Malformed HTML")
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_raw_html_no_closing_tag() {
+        init_test_config();
+        assert_eq!(
+            parse_block(tokenize("<div>Unclosed HTML")),
+            Some(RawHtml {
+                content: String::from("<div>Unclosed HTML")
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_raw_html_mismatched_tags() {
+        init_test_config();
+        assert_eq!(
+            parse_block(tokenize("<div>Unmatched </span> tags")),
+            Some(RawHtml {
+                content: String::from("<div>Unmatched </span> tags")
             })
         );
     }
@@ -1908,6 +1976,46 @@ mod html_generation {
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
                 "<h1>This is a heading with <strong>bold text</strong> and <em>italic text</em>.</h1><div>Some raw HTML content</div>\n"
+            );
+        }
+
+        #[test]
+        fn malformed_raw_html_no_closing_bracket() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![tokenize(
+                    "<div Missing bracket"
+                )]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<p><div Missing bracket</p>"
+            );
+        }
+
+        #[test]
+        fn malformed_raw_html_closing_tag() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![tokenize("<div>Unclosed tag")]))
+                    .iter()
+                    .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                    .collect::<String>(),
+                "<div>Unclosed tag\n"
+            );
+        }
+
+        #[test]
+        fn malformed_raw_html_mismatched_tags() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![tokenize(
+                    "<div>Unmatched <span> tags"
+                )]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<div>Unmatched <span> tags\n"
             );
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,6 +30,7 @@ pub enum Token {
     Tab,
     Newline,
     BlockQuoteMarker,
+    RawHtmlTag(String),
 }
 
 impl From<String> for Token {
@@ -65,6 +66,9 @@ pub enum MdBlockElement {
     },
     BlockQuote {
         content: Vec<MdBlockElement>,
+    },
+    RawHtml {
+        content: String,
     },
 }
 
@@ -140,6 +144,9 @@ impl ToHtml for MdBlockElement {
                     .map(|el| el.to_html(output_dir, input_dir, html_rel_path))
                     .collect::<String>();
                 format!("<blockquote>{inner_html}</blockquote>")
+            }
+            MdBlockElement::RawHtml { content } => {
+                format!("{}\n", content.clone())
             }
         }
     }


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for raw HTML in input Markdown files, and fixed bugs involving line grouping.

## More Details

<!-- Describe the changes made in this pull request -->

- There is a new `Token::RawHtmlTag` variant
- There is a new `MdBlockElement::RawHtml` variant
- Lines that begin with spaces now properly group with previous lines (i.e. text, space-indented elements, etc.)
- Lines that begin with tabs and start with HTML will now group with previous lines if they also started with HTML
- The README has been updated with information about using raw HTML as input
  - More specifically, it warns that currently Mark-rs does not sanitize the HTML so that users can use tags like `<script>`, `<embed>`, etc.
  - However, these tags make pages potentially vulnerable to XSS attacks, so there is a warning regarding raw HTML and links to [OWASP](https://owasp.org/www-community/attacks/xss/) and the [OWASP XSS Prevention Cheat Sheet.](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) for more information

## Test Updates

<!-- Describe the tests that you created for this pull request -->

- There are new tests for tokenizing, parsing, and generating HTML for raw HTML input
- There are tests for using both Markdown and raw HTML in a line