### PR TITLE
Add support for indented code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is designed to be fast, efficient, and easy to use.
 - [Mark-rs](#mark-rs)
   - [Table of Contents](#table-of-contents)
   - [Features](#features)
-  - [Installation (WIP)](#installation-wip)
+  - [Installation](#installation)
   - [Usage](#usage)
     - [Options](#options)
   - [Configuration](#configuration)
@@ -72,6 +72,15 @@ You can also download pre-built binaries for your platform from the [releases pa
 
 From there, you can download the appropriate binary for your operating system and architecture, extract it, and use it directly.
 
+### Updates
+
+If Mark-rs was installed using Cargo, you can update it to the latest version by running:
+
+```bash
+cargo install mark-rs
+```
+
+If you installed Mark-rs using pre-built binaries, you can download the latest version from the [releases page](https://github.com/zliel/Mark-rs/releases)
 
 ## Usage
 

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -357,7 +357,6 @@ pub fn generate_default_css() -> String {
     td {
     padding: 0.75rem 1rem;
     text-align: left;
-    border-bottom: 1px solid #333;
     }
 
     th {
@@ -376,6 +375,7 @@ pub fn generate_default_css() -> String {
 
     td {
     color: #ddd;
+    border-top: 1px solid #333;
     }
 
     hr {

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -296,13 +296,31 @@ pub fn generate_default_css() -> String {
     font-size: 0.9rem;
     box-shadow: inset 0 0 0 1px #333;
     }
+    pre::before {
+    counter-reset: listing;
+    }
     code {
     font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     background-color: #2a2a2a;
-    padding: 0.2em 0.4em;
+    counter-increment: listing;
+    padding: 0 0.4em;
     border-radius: 4px;
     font-size: 0.95em;
     color: #dcdcdc;
+    text-align: left;
+    float: left;
+    clear: left;
+    }
+    pre code::before {
+    content: counter(listing) ". ";
+    display: inline-block;
+    font-size: 0.85em;
+    float: left;
+    height: 1em;
+    padding-top: 0.2em;
+    padding-left: auto;
+    margin-left: auto;
+    text-align: right;
     }
 
     blockquote {

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -344,7 +344,7 @@ pub fn generate_default_css() -> String {
 
     table {
     width: 100%;
-    border-collapse: collapse;
+    border-spacing: 0;
     margin: 2rem 0;
     background-color: #1e1e1e;
     border: 1px solid #333;

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -302,11 +302,14 @@ pub fn generate_default_css() -> String {
     code {
     font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     background-color: #2a2a2a;
-    counter-increment: listing;
-    padding: 0 0.4em;
+    padding: 0.2em 0.4em;
     border-radius: 4px;
     font-size: 0.95em;
     color: #dcdcdc;
+    }
+    pre code {
+    counter-increment: listing;
+    padding: 0 0.4em;
     text-align: left;
     float: left;
     clear: left;

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -301,6 +301,7 @@ pub fn generate_default_css() -> String {
     }
     code {
     font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-style: normal;
     background-color: #2a2a2a;
     padding: 0.2em 0.4em;
     border-radius: 4px;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1191,6 +1191,9 @@ fn group_ordered_list(
 
 /// Groups tabbed lines into blocks based on the previous block's content.
 ///
+/// Note that this function short-circuits when the first token of the line is a raw HTML tag,
+/// to allow for indented HTML.
+///
 /// # Arguments
 /// * `blocks` - A mutable reference to a vector of blocks, where each block is a vector of tokens.
 /// * `current_block` - A mutable reference to the current block being processed.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -102,6 +102,14 @@ fn parse_raw_html(line: Vec<Token>) -> MdBlockElement {
     }
 }
 
+/// Parses a blockquote from a vector of tokens into an `MdBlockElement::BlockQuote`.
+///
+/// # Arguments
+/// * `line` - A vector of tokens representing a blockquote.
+///
+/// # Returns
+/// An `MdBlockElement::BlockQuote` containing the parsed content, or a `MdBlockElement::Paragraph`
+/// if the content is empty.
 fn parse_blockquote(line: Vec<Token>) -> MdBlockElement {
     let lines_split_by_newline = line
         .split(|token| *token == Token::Newline)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1088,6 +1088,14 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
     blocks
 }
 
+/// Groups lines beginning with "|" denoting Markdown tables.
+///
+/// # Arguments
+/// * `blocks` - A mutable reference to a vector of blocks, where each block is a vector of tokens.
+/// * `current_block` - A mutable reference to the current block being processed.
+/// * `previous_block` - A mutable reference to the previous block, used for context.
+/// * `line` - A mutable reference to the current line being processed, which is a vector of
+///   tokens.
 fn group_table_rows(
     blocks: &mut Vec<Vec<Token>>,
     current_block: &mut Vec<Token>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1262,6 +1262,14 @@ fn group_tabbed_lines(
     }
 }
 
+/// Groups lines with leading whitespace into blocks based on the previous block's content.
+///
+/// # Arguments
+/// * `blocks` - A mutable reference to a vector of blocks, where each block is a vector of tokens.
+/// * `current_block` - A mutable reference to the current block being processed.
+/// * `previous_block` - A mutable reference to the previous block, used for context.
+/// * `line` - A mutable reference to the current line being processed, which is a vector of
+///   tokens.
 fn group_lines_with_leading_whitespace(
     blocks: &mut Vec<Vec<Token>>,
     current_block: &mut Vec<Token>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -364,7 +364,6 @@ fn parse_codeblock(line: Vec<Token>) -> MdBlockElement {
         if line.is_empty() {
             return;
         }
-        println!("Processing line: {:?}", line);
 
         for token in line.iter() {
             match token {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -118,7 +118,12 @@ fn parse_indented_codeblock(line: Vec<Token>) -> MdBlockElement {
                 Token::CodeTick => line_buffer.push('`'),
                 Token::CodeFence => line_buffer.push_str("```"),
                 Token::BlockQuoteMarker => line_buffer.push('>'),
-                _ => {}
+                Token::ThematicBreak => line_buffer.push_str("---"),
+                Token::RawHtmlTag(tag_content) => {
+                    // This should never be the first token, but inline html is allowed
+                    let escaped_tag = tag_content.replace("<", "&lt;").replace(">", "&gt;");
+                    line_buffer.push_str(escaped_tag.as_str());
+                }
             }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1271,6 +1271,7 @@ fn group_ordered_list(
     }
 }
 
+/// Attaches the current line to the previous block, optionally adding a separator token.
 fn attach_to_previous_block(
     blocks: &mut Vec<Vec<Token>>,
     previous_block: &mut Vec<Token>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,6 +67,14 @@ fn parse_block(line: Vec<Token>) -> Option<MdBlockElement> {
     }
 }
 
+
+/// Parses raw HTML tags from a vector of tokens into an `MdBlockElement::RawHtml`.
+///
+/// # Arguments
+/// * `line` - A vector of tokens representing a line of raw HTML.
+///
+/// # Returns
+/// An `MdBlockElement::RawHtml` containing the parsed HTML content.
 fn parse_raw_html(line: Vec<Token>) -> MdBlockElement {
     let mut html_content = String::new();
     for token in line {
@@ -829,6 +837,7 @@ fn flatten_inline(elements: Vec<MdInlineElement>) -> String {
     }
     result
 }
+
 /// Parses (resolves) emphasis in a vector of inline Markdown elements.
 ///
 /// Modifies the elements in place to convert delimiter runs into bold or italic elements as appropriate.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -966,8 +966,8 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
         // Appending all tokens between two code fences to one block
         if is_inside_code_block && line.first() != Some(&Token::CodeFence) {
             // If we are inside a code block, then we just append the line to the current block
-            previous_block.extend(line.to_owned());
             previous_block.push(Token::Newline);
+            previous_block.extend(line.to_owned());
             blocks.pop();
             blocks.push(previous_block.clone());
             continue;

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -670,7 +670,7 @@ mod block {
                     language: Some(String::from("rust")),
                     lines: vec![
                         String::from("fn main() {"),
-                        String::from("println!(\"Hello, world!\");"),
+                        String::from("    println!(\"Hello, world!\");"),
                         String::from("}")
                     ]
                 }

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -668,9 +668,11 @@ mod block {
                 },
                 CodeBlock {
                     language: Some(String::from("rust")),
-                    lines: vec![String::from(
-                        "fn main() {\nprintln!(\"Hello, world!\");\n}\n"
-                    )]
+                    lines: vec![
+                        String::from("fn main() {"),
+                        String::from("println!(\"Hello, world!\");"),
+                        String::from("}")
+                    ]
                 }
             ]
         )
@@ -1007,7 +1009,7 @@ mod block {
             parse_block(tokenize("```\ncode block\n```")),
             Some(CodeBlock {
                 language: None,
-                lines: vec![String::from("code block\n")]
+                lines: vec![String::from("code block")]
             })
         );
     }
@@ -1019,7 +1021,7 @@ mod block {
             parse_block(tokenize("```rust\nfn main() {}\n```")),
             Some(CodeBlock {
                 language: Some(String::from("rust")),
-                lines: vec![String::from("\nfn main() {}\n")]
+                lines: vec![String::from("fn main() {}")]
             })
         );
     }
@@ -1804,7 +1806,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<pre><code>code block\nsecond line\n</code></pre>"
+                "<pre><code>code block</code>\n<code>second line</code></pre>"
             );
         }
 
@@ -1821,7 +1823,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>"
+                "<pre><code class=\"language-rust\">fn main() {}</code></pre>"
             );
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,15 +90,18 @@ impl ToHtml for MdBlockElement {
                 format!("<p>{inner_html}</p>")
             }
             MdBlockElement::CodeBlock { language, lines } => {
-                let code = lines.join("\n");
-                match language {
-                    Some(language) => {
-                        format!("<pre><code class=\"language-{language}\">{code}</code></pre>")
-                    }
-                    None => {
-                        format!("<pre><code>{code}</code></pre>")
-                    }
-                }
+                let code = lines
+                    .iter()
+                    .map(|line| match language {
+                        Some(language) => {
+                            format!("<code class=\"language-{language}\">{line}</code>")
+                        }
+                        None => format!("<code>{line}</code>"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                format!("<pre>{code}</pre>")
             }
             MdBlockElement::ThematicBreak => "<hr>".to_string(),
             MdBlockElement::UnorderedList { items } => {


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for indented code blocks, added line numbers to code blocks, and added an "Updates" section to the README

## More Details

<!-- Describe the changes made in this pull request -->

- Any line that begins with a Token::Tab will be grouped along with other tabbed lines and parsed as a `MdBlockElement::CodeBlock`
  - The one exception to this is lines that are tabbed but start with an HTML tag.  
- Codeblocks now all have line numbers
  - More on that, there is now a specific style section for `<code>` elements that are children of `<pre>` elements.
  - In addition, `MdBlockElement::CodeBlock` now convert each line of code into individual `<code>` elements to allow for line numbers
- Fenced codeblocks now support tabs, raw HTML, and thematic breaks
- Indented codeblocks now support raw HTML so long as the HTML is not the first non-whitespace token
- Minor bugfix where tables had two borders: one that was square, and one that was rounded
- In the grouping functions, instead of calling `previous_block.push(Token::Newline);...blocks.push(previous_block);` repeatedly, there is now a helper function, `attach_to_previous_block` that performs the same actions, with a passed in separator `Token`.
  - Now the following line can be used instead of the one mentioned above: 
  `attach_to_previous_block(blocks, previous_block, line, Some(Token::Newline));`


## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- Tests for `MdBlockElement::CodeBlock` now expect the `lines` attribute to consist of multiple strings
- Tests for the HTML generation of CodeBlocks now expects each line to be in its own set  of `<code>` tags

## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->

### Indented Codeblocks

For the following input:
```
    This is an indented codeblock
    It spans multiple lines
    <h2>But is interrupted by HTML</h2>

     This is a second code block
```

This is the generated codeblock:
<img width="1066" height="411" alt="image" src="https://github.com/user-attachments/assets/448ce49e-d360-46c5-8d6c-6491ee929a01" />

### Line numbers

For the following input:
\`\`\`rust
pub fn hello_world() {
    println!("Hello, world!");
}
\`\`\`

This is the generated codeblock:
<img width="1075" height="259" alt="image" src="https://github.com/user-attachments/assets/f02170a0-06ea-4314-8197-da4a7faca664" />

