### PR TITLE
Version bump to v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mark-rs"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "A Markdown parser and Static Site Generator"
 edition = "2024"
 name = "mark-rs"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT OR Apache-2.0"
 keywords = ["markdown", "cli", "ssg", "static_site", "notes"]
 repository = "https://github.com/zliel/Mark-rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ static CONFIG: OnceLock<Config> = OnceLock::new();
 #[derive(Parser, Debug)]
 #[command(
     author = "Zackary Liel",
-    version = "1.1.0",
+    version = "1.2.0",
     about = "A Commonmark compliant markdown parser and static site generator.",
     override_usage = "markrs [OPTIONS] <INPUT_DIR>"
 )]


### PR DESCRIPTION
This is a PR to bump up the version of `Mark-rs` to `v1.2.0`