### PR TITLE
Add support for prismjs highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mark-rs"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "A Markdown parser and Static Site Generator"
 edition = "2024"
 name = "mark-rs"
-version = "1.2.1"
+version = "1.3.0"
 license = "MIT OR Apache-2.0"
 keywords = ["markdown", "cli", "ssg", "static_site", "notes"]
 repository = "https://github.com/zliel/Mark-rs"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ css_file = "default" # "default" for the default styles
 favicon_file = ""    # Empty for no favicon
 use_prism = false    # If "true", the CDN links for PrismJS will be used for codeblock highlighting
 # Note that `use_prism = true` this will add `<script>` and `<link>` elements to the page
+prism_theme = "vsc-dark-plus" # Will only take effect if "use_prism" is set to "true"
+# See https://github.com/PrismJS/prism-themes for themes and https://cdnjs.com/libraries/prism-themes for what to set "prism_theme" to
 ```
 
 ## ⚠️Note: Raw HTML

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ tab_size = 4
 [html]
 css_file = "default" # "default" for the default styles
 favicon_file = ""    # Empty for no favicon
+use_prism = false    # If "true", the CDN links for PrismJS will be used for codeblock highlighting
+# Note that `use_prism = true` this will add `<script>` and `<link>` elements to the page
 ```
 
 ## ⚠️Note: Raw HTML

--- a/config.toml
+++ b/config.toml
@@ -8,3 +8,5 @@ css_file = "default" # "default" for the default styles
 favicon_file = ""    # Empty for no favicon
 use_prism = false    # If "true", the CDN links for PrismJS will be used for codeblock highlighting
 # Note that `use_prism = true` this will add `<script>` and `<link>` elements to the page
+prism_theme = "vsc-dark-plus" # Will only take effect if "use_prism" is set to "true"
+# See https://github.com/PrismJS/prism-themes for themes and https://cdnjs.com/libraries/prism-themes for what to set "prism_theme" to

--- a/config.toml
+++ b/config.toml
@@ -6,3 +6,5 @@ tab_size = 4
 [html]
 css_file = "default" # "default" for the default styles
 favicon_file = ""    # Empty for no favicon
+use_prism = false    # If "true", the CDN links for PrismJS will be used for codeblock highlighting
+# Note that `use_prism = true` this will add `<script>` and `<link>` elements to the page

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct HtmlConfig {
     pub favicon_file: String,
     #[serde(default = "bool::default")]
     pub use_prism: bool,
+    #[serde(default = "String::new")]
+    pub prism_theme: String,
 }
 
 /// Sets the default CSS file to "default" in the case that the `css_file` field is omitted
@@ -76,6 +78,7 @@ impl Config {
                     css_file: default_css(),
                     favicon_file: String::new(),
                     use_prism: false,
+                    prism_theme: String::new(),
                 },
             };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct HtmlConfig {
     #[serde(default = "default_css")]
     pub css_file: String,
     pub favicon_file: String,
+    #[serde(default = "bool::default")]
+    pub use_prism: bool,
 }
 
 /// Sets the default CSS file to "default" in the case that the `css_file` field is omitted
@@ -73,6 +75,7 @@ impl Config {
                 html: HtmlConfig {
                     css_file: default_css(),
                     favicon_file: String::new(),
+                    use_prism: false,
                 },
             };
 

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -88,6 +88,7 @@ pub fn generate_index(file_names: &[String]) -> String {
 /// * `html_rel_path` - The relative path to the HTML file from the output directory, used for
 ///   linking
 fn generate_head(file_name: &str, html_rel_path: &str) -> String {
+    let config = CONFIG.get().unwrap();
     let mut head = String::from(
         r#"<!DOCTYPE html>
     <html lang="en">
@@ -101,7 +102,7 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
     let title = format_title(file_name);
     head.push_str(&format!("<title>{}</title>\n", title));
 
-    let favicon_file = CONFIG.get().unwrap().html.favicon_file.clone();
+    let favicon_file = config.html.favicon_file.clone();
     if !favicon_file.is_empty() {
         let mut favicon_path = build_rel_prefix(html_rel_path);
         favicon_path.push("media");
@@ -111,7 +112,7 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
         head.push_str(&format!("<link rel=\"icon\" href=\"{}\">\n", favicon_href));
     }
 
-    let css_file = CONFIG.get().unwrap().html.css_file.clone();
+    let css_file = config.html.css_file.clone();
     let mut css_path = build_rel_prefix(html_rel_path);
     css_path.push("styles.css");
     let css_href = css_path.to_string_lossy();

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -49,6 +49,8 @@ pub fn generate_html(
             "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/autoloader/prism-autoloader.min.js\" integrity=\"sha512-SkmBfuA2hqjzEVpmnMt/LINrjop3GKWqsuLSSB3e7iBmYK7JuWw4ldmmxwD9mdm2IRTTi0OxSAfEGvgEi0i2Kw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
         );
 
+    body.push_str("\n</body>\n");
+
     html_output.push_str(&head);
     html_output.push_str(&body);
     html_output.push_str("</html>\n");

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -48,6 +48,8 @@ pub fn generate_html(
         body.push_str(
             "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/autoloader/prism-autoloader.min.js\" integrity=\"sha512-SkmBfuA2hqjzEVpmnMt/LINrjop3GKWqsuLSSB3e7iBmYK7JuWw4ldmmxwD9mdm2IRTTi0OxSAfEGvgEi0i2Kw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
         );
+        body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/toolbar/prism-toolbar.min.js\" integrity=\"sha512-st608h+ZqzliahyzEpETxzU0f7z7a9acN6AFvYmHvpFhmcFuKT8a22TT5TpKpjDa3pt3Wv7Z3SdQBCBdDPhyWA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
+        body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js\" integrity=\"sha512-/kVH1uXuObC0iYgxxCKY41JdWOkKOxorFVmip+YVifKsJ4Au/87EisD1wty7vxN2kAhnWh6Yc8o/dSAXj6Oz7A==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
 
     body.push_str("\n</body>\n");
 
@@ -139,6 +141,7 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
 
     if config.html.use_prism {
             head.push_str("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism-okaidia.min.css\">");
+        head.push_str("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/toolbar/prism-toolbar.min.css\" integrity=\"sha512-Dqf5696xtofgH089BgZJo2lSWTvev4GFo+gA2o4GullFY65rzQVQLQVlzLvYwTo0Bb2Gpb6IqwxYWtoMonfdhQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />");
         head.push_str("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/line-numbers/prism-line-numbers.min.css\" integrity=\"sha512-cbQXwDFK7lj2Fqfkuxbo5iD1dSbLlJGXGpfTDqbggqjHJeyzx88I3rfwjS38WJag/ihH7lzuGlGHpDBymLirZQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />");
     }
 

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -44,6 +44,7 @@ pub fn generate_html(
         body.push_str(
             "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/components/prism-core.min.js\" integrity=\"sha512-Uw06iFFf9hwoN77+kPl/1DZL66tKsvZg6EWm7n6QxInyptVuycfrO52hATXDRozk7KWeXnrSueiglILct8IkkA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>",
         );
+        body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/line-numbers/prism-line-numbers.min.js\" integrity=\"sha512-BttltKXFyWnGZQcRWj6osIg7lbizJchuAMotOkdLxHxwt/Hyo+cl47bZU0QADg+Qt5DJwni3SbYGXeGMB5cBcw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
         body.push_str(
             "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/autoloader/prism-autoloader.min.js\" integrity=\"sha512-SkmBfuA2hqjzEVpmnMt/LINrjop3GKWqsuLSSB3e7iBmYK7JuWw4ldmmxwD9mdm2IRTTi0OxSAfEGvgEi0i2Kw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
         );
@@ -136,6 +137,7 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
 
     if config.html.use_prism {
             head.push_str("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism-okaidia.min.css\">");
+        head.push_str("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/line-numbers/prism-line-numbers.min.css\" integrity=\"sha512-cbQXwDFK7lj2Fqfkuxbo5iD1dSbLlJGXGpfTDqbggqjHJeyzx88I3rfwjS38WJag/ihH7lzuGlGHpDBymLirZQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />");
     }
 
     head.push_str("</head>\n");

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -288,7 +288,8 @@ pub fn generate_default_css() -> String {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     }
 
-    pre {
+    /* Styles for when "use_prism = false" is set in config.toml */
+    pre.non_prism {
     background-color: #2a2a2a;
     padding: 1rem;
     border-radius: 8px;
@@ -296,10 +297,10 @@ pub fn generate_default_css() -> String {
     font-size: 0.9rem;
     box-shadow: inset 0 0 0 1px #333;
     }
-    pre::before {
+    pre.non_prism::before {
     counter-reset: listing;
     }
-    code {
+    code.non_prism {
     font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     font-style: normal;
     background-color: #2a2a2a;
@@ -308,14 +309,14 @@ pub fn generate_default_css() -> String {
     font-size: 0.95em;
     color: #dcdcdc;
     }
-    pre code {
+    pre.non_prism code.non_prism {
     counter-increment: listing;
     padding: 0 0.4em;
     text-align: left;
     float: left;
     clear: left;
     }
-    pre code::before {
+    pre.non_prism code.non_prism::before {
     content: counter(listing) ". ";
     display: inline-block;
     font-size: 0.85em;
@@ -325,6 +326,10 @@ pub fn generate_default_css() -> String {
     padding-left: auto;
     margin-left: auto;
     text-align: right;
+    }
+
+    code {
+    font-style: normal;
     }
 
     blockquote {

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -362,6 +362,12 @@ pub fn generate_default_css() -> String {
     border-radius: 2px;
     }
 
+    /* "button.copy-to-clipboard-button matches PrismJS' clipboard button */
+    button.copy-to-clipboard-button {
+    font-style: normal;
+    margin-right: 0.2em;
+    }
+
     ul,
     ol {
     padding-left: 1.5rem;

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -368,8 +368,7 @@ pub fn generate_default_css() -> String {
     border-radius: 2px;
     }
 
-    /* "button.copy-to-clipboard-button matches PrismJS' clipboard button */
-    button.copy-to-clipboard-button {
+    .toolbar-item {
     font-style: normal;
     margin-right: 0.2em;
     }

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -38,7 +38,15 @@ pub fn generate_html(
         .join("\n");
 
     body.push_str(&inner_html);
-    body.push_str("\n</div>\n</body>\n");
+    body.push_str("\n</div>");
+
+    if CONFIG.get().unwrap().html.use_prism {
+        body.push_str(
+            "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/components/prism-core.min.js\" integrity=\"sha512-Uw06iFFf9hwoN77+kPl/1DZL66tKsvZg6EWm7n6QxInyptVuycfrO52hATXDRozk7KWeXnrSueiglILct8IkkA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>",
+        );
+        body.push_str(
+            "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/autoloader/prism-autoloader.min.js\" integrity=\"sha512-SkmBfuA2hqjzEVpmnMt/LINrjop3GKWqsuLSSB3e7iBmYK7JuWw4ldmmxwD9mdm2IRTTi0OxSAfEGvgEi0i2Kw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
+        );
 
     html_output.push_str(&head);
     html_output.push_str(&body);
@@ -124,6 +132,10 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
             "<link rel=\"stylesheet\" href=\"{}\">\n",
             css_file
         ));
+    }
+
+    if config.html.use_prism {
+            head.push_str("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism-okaidia.min.css\">");
     }
 
     head.push_str("</head>\n");

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -50,6 +50,8 @@ pub fn generate_html(
         );
         body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/toolbar/prism-toolbar.min.js\" integrity=\"sha512-st608h+ZqzliahyzEpETxzU0f7z7a9acN6AFvYmHvpFhmcFuKT8a22TT5TpKpjDa3pt3Wv7Z3SdQBCBdDPhyWA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
         body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js\" integrity=\"sha512-/kVH1uXuObC0iYgxxCKY41JdWOkKOxorFVmip+YVifKsJ4Au/87EisD1wty7vxN2kAhnWh6Yc8o/dSAXj6Oz7A==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
+        body.push_str("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/show-language/prism-show-language.min.js\" integrity=\"sha512-d1t+YumgzdIHUL78me4B9NzNTu9Lcj6RdGVbdiFDlxRV9JTN9s+iBQRhUqLRq5xtWUp1AD+cW2sN2OlST716fw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
+    }
 
     body.push_str("\n</body>\n");
 

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -142,7 +142,11 @@ fn generate_head(file_name: &str, html_rel_path: &str) -> String {
     }
 
     if config.html.use_prism {
+        if !config.html.prism_theme.is_empty() {
+            head.push_str(format!("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism-themes/1.9.0/prism-{}.min.css\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />", config.html.prism_theme).as_str());
+        } else {
             head.push_str("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism-okaidia.min.css\">");
+        }
         head.push_str("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/toolbar/prism-toolbar.min.css\" integrity=\"sha512-Dqf5696xtofgH089BgZJo2lSWTvev4GFo+gA2o4GullFY65rzQVQLQVlzLvYwTo0Bb2Gpb6IqwxYWtoMonfdhQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />");
         head.push_str("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/line-numbers/prism-line-numbers.min.css\" integrity=\"sha512-cbQXwDFK7lj2Fqfkuxbo5iD1dSbLlJGXGpfTDqbggqjHJeyzx88I3rfwjS38WJag/ihH7lzuGlGHpDBymLirZQ==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\" />");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ static CONFIG: OnceLock<Config> = OnceLock::new();
 #[derive(Parser, Debug)]
 #[command(
     author = "Zackary Liel",
-    version = "1.2.1",
+    version = "1.3.0",
     about = "A Commonmark compliant markdown parser and static site generator.",
     override_usage = "markrs [OPTIONS] <INPUT_DIR>"
 )]

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1806,7 +1806,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<pre><code>code block</code>\n<code>second line</code></pre>"
+                "<pre class=\"non_prism\"><code class=\"non_prism\">code block</code>\n<code class=\"non_prism\">second line</code></pre>"
             );
         }
 
@@ -1823,7 +1823,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<pre><code class=\"language-rust\">fn main() {}</code></pre>"
+                "<pre class=\"non_prism\"><code class=\"non_prism\">fn main() {}</code></pre>"
             );
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,6 +90,18 @@ impl ToHtml for MdBlockElement {
                 format!("<p>{inner_html}</p>")
             }
             MdBlockElement::CodeBlock { language, lines } => {
+                let language_class = match language {
+                    Some(language) => format!("language-{language}"),
+                    None => "language-none".to_string(),
+                };
+
+                if CONFIG.get().unwrap().html.use_prism {
+                    let code = lines.join("\n");
+
+                    format!(
+                        "<pre class=\"{language_class} line-numbers\" style=\"white-space: pre-wrap;\" data-prismjs-copy=\"📋\"><code class=\"{language_class} line-numbers\">{code}</code></pre>"
+                    )
+                } else {
                     let code = lines
                         .iter()
                         .map(|line| format!("<code class=\"non_prism\">{line}</code>"))
@@ -97,6 +109,7 @@ impl ToHtml for MdBlockElement {
                         .join("\n");
 
                     format!("<pre class=\"non_prism\">{code}</pre>")
+                }
             }
             MdBlockElement::ThematicBreak => "<hr>".to_string(),
             MdBlockElement::UnorderedList { items } => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,18 +90,13 @@ impl ToHtml for MdBlockElement {
                 format!("<p>{inner_html}</p>")
             }
             MdBlockElement::CodeBlock { language, lines } => {
-                let code = lines
-                    .iter()
-                    .map(|line| match language {
-                        Some(language) => {
-                            format!("<code class=\"language-{language}\">{line}</code>")
-                        }
-                        None => format!("<code>{line}</code>"),
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                    let code = lines
+                        .iter()
+                        .map(|line| format!("<code class=\"non_prism\">{line}</code>"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
 
-                format!("<pre>{code}</pre>")
+                    format!("<pre class=\"non_prism\">{code}</pre>")
             }
             MdBlockElement::ThematicBreak => "<hr>".to_string(),
             MdBlockElement::UnorderedList { items } => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 //! This module defines the types used in the markdown parser, including tokens, inline elements,
 //! block elements, and a cursor for navigating through tokens.
 
-use log::{info, warn};
+use log::warn;
 
 use crate::{CONFIG, io::copy_image_to_output_dir, utils::build_rel_prefix};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 //! This module defines the types used in the markdown parser, including tokens, inline elements,
 //! block elements, and a cursor for navigating through tokens.
 
-use log::warn;
+use log::{info, warn};
 
-use crate::{io::copy_image_to_output_dir, utils::build_rel_prefix};
+use crate::{CONFIG, io::copy_image_to_output_dir, utils::build_rel_prefix};
 
 pub trait ToHtml {
     /// Converts the implementing type to an String representing its HTML equivalent.


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added a configuration option that allows users to opt in to using PrismJS for more advanced codeblocks.

## More Details

<!-- Describe the changes made in this pull request -->

### Config
- There's a new boolean `use_prism` field, along with a note about how `<script>` and `<link>` tags will be inserted into the HTML
- There's a new String `prism_theme` field, along with a note about where to find supported themes and their names

### HTML Generation
- When not using PrismJS, `<pre><code>` blocks will have the class `non_prism` on every element.
- When using PrismJS, `MdBlockElement::CodeBlock` elements will now join their inner lines into one big `<code>` element
  - `<pre>` tags will be as follows: `<pre class="{language_class} line-numbers" style="white-space: pre-wrap;" data-prismjs-copy="📋">`, where `{language_class}` is either `language-none` or the `CodeBlock`'s `language` attribute
  - `<code>` tags are very similar, `<code class="{language_class} line-numbers">`

### PrismJS
- When using PrismJS, the following plugins will be added via `<link>` and `<script>` tags:
  - [`Autoloader`](https://prismjs.com/plugins/autoloader): Sets up PrismJS, adding classes and editing the `<pre><code>` blocks
  - [`Copy to Clipboard`](https://prismjs.com/plugins/copy-to-clipboard): Adds a button to codeblocks that lets you copy the code content to your clipboard
  - [`Show Language`](https://prismjs.com/plugins/show-language): Adds text to the codeblocks that says what language the code contains ("Plain Text" if the language is `language-none`)
  - [`Toolbar`](https://prismjs.com/plugins/toolbar): Dependency for `Copy to Clipboard` and `Show Language`, sets up the added content in the top right of the codeblock container

## Test Updates

<!-- Describe the tests that you created for this pull request -->

- Because `use_prism` is false in the default configuration, tests now expect `<pre>` and `<code>` attributes to have the `non_prism` class

## New Dependencies

<!-- List any new dependencies added in this pull request -->

- No new Cargo dependencies, but if `use_prism` is set to true, `<link>` and `<script>` elements will use [cdnjs.com](https://www.cdnjs.com) to set up PrismJS for each page.

## Screenshots

<!-- Add screenshots to help showcase your changes -->

For the following input:

\`\`\`rust
fn greet_user(name: &str) -> Result<String, String> {
    if name.trim().is_empty() {
        Err(String::from("Name cannot be empty"))
    } else {
        Ok(format!("Hello, {}!", name))
    }
}

fn main() {
    match greet_user("Zackary") {
        Ok(message) => println!("{}", message),
        Err(e) => eprintln!("Error: {}", e),
    }
}
\`\`\`
(Note that spacing was not preserved in the rendered version of that on GitHub)

The following was generated:

With PrismJS (using the "vsc-dark-plus" theme):
<img width="1070" height="474" alt="image" src="https://github.com/user-attachments/assets/c0104f67-41e5-4bd1-aa0e-9f508cae858f" />

Without PrismJS (using default styles):
<img width="1096" height="573" alt="image" src="https://github.com/user-attachments/assets/7e2d70db-58f4-4340-bbc3-8d08624df53f" />
