### PR TITLE
Make config update automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "log",
  "serde",
  "toml",
+ "toml_edit",
  "unicode-segmentation",
  "unicode_categories",
 ]
@@ -919,6 +920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dee9dc43ac2aaf7d3b774e2fba5148212bf2bd9374f4e50152ebe9afd03d42"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1090,9 @@ name = "winnow"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.11.8"
 log = "0.4.27"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.2"
+toml_edit = "0.23.2"
 unicode-segmentation = "1.12.0"
 unicode_categories = "0.1.1"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,6 +175,12 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
             missing_fields, file_path
         );
 
+        // Formats the file with sections like `[lexer]` and `tab_size = 4`
+        // previously it would be `lexer = { tab_size = 4 }`
+        doc.set_implicit(true);
+        doc["lexer"].as_table_mut().unwrap().set_position(0);
+        doc["html"].as_table_mut().unwrap().sort_values();
+
         std::fs::write(file_path, doc.to_string())
             .map_err(|e| format!("Failed to write config file: {}", e))?;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,17 +109,11 @@ impl Config {
 
             Ok(config)
         } else {
-            // Write the default config if it does not exist
-            let default_config = Config {
-                lexer: LexerConfig { tab_size: 4 },
-                html: HtmlConfig {
-                    css_file: default_css(),
-                    favicon_file: String::new(),
-                    use_prism: false,
-                    prism_theme: String::new(),
-                    sanitize_html: true,
-                },
-            };
+            warn!(
+                "No config file found, writing default config to: {}",
+                config_path.to_string_lossy()
+            );
+            let default_config = Config::default();
 
             write_default_config(&default_config)
                 .map_err(|e| format!("Failed to write default config: {}", e))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,16 +6,29 @@ use crate::CONFIG;
 use crate::io::{does_config_exist, get_config_path, write_default_config};
 
 /// Represents the global configuration for the application.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Config {
+    #[serde(default)]
     pub lexer: LexerConfig,
+    #[serde(default)]
     pub html: HtmlConfig,
 }
 
 /// Manages all configuration for tokenization
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LexerConfig {
+    #[serde(default = "default_tab_size")]
     pub tab_size: usize,
+}
+
+impl Default for LexerConfig {
+    fn default() -> Self {
+        LexerConfig { tab_size: 4 }
+    }
+}
+
+fn default_tab_size() -> usize {
+    4
 }
 
 /// Manages all configuration for HTML generation
@@ -23,12 +36,36 @@ pub struct LexerConfig {
 pub struct HtmlConfig {
     #[serde(default = "default_css")]
     pub css_file: String,
+    #[serde(default)]
     pub favicon_file: String,
-    #[serde(default = "bool::default")]
+    #[serde(default)]
     pub use_prism: bool,
-    #[serde(default = "String::new")]
+    #[serde(default = "default_prism_theme")]
     pub prism_theme: String,
+    #[serde(default = "sanitize_by_default")]
     pub sanitize_html: bool,
+}
+
+impl Default for HtmlConfig {
+    fn default() -> Self {
+        HtmlConfig {
+            css_file: default_css(),
+            favicon_file: "".to_string(),
+            use_prism: false,
+            prism_theme: default_prism_theme(),
+            sanitize_html: sanitize_by_default(),
+        }
+    }
+}
+
+/// Sets the default PrismJS theme to "vsc-dark-plus" in `config.toml`
+fn default_prism_theme() -> String {
+    "vsc-dark-plus".to_string()
+}
+
+/// Sets `sanitize_html` to true by default in `config.toml`
+fn sanitize_by_default() -> bool {
+    true
 }
 
 /// Sets the default CSS file to "default" in the case that the `css_file` field is omitted

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,12 +99,12 @@ impl Config {
             return Ok(config);
         }
 
+        let config_path =
+            get_config_path().map_err(|e| format!("Failed to get config path: {}", e))?;
+
         // If the user did not provide a config file, check if a config file exists in the config
         // directory
         if does_config_exist()? {
-            let config_path =
-                get_config_path().map_err(|e| format!("Failed to get config path: {}", e))?;
-
             let contents = std::fs::read_to_string(&config_path)
                 .map_err(|e| format!("Failed to read config file: {}", e))?;
 

--- a/src/lexer/test.rs
+++ b/src/lexer/test.rs
@@ -1,13 +1,14 @@
 use std::sync::Once;
 
-use crate::config::init_config;
+use crate::CONFIG;
+use crate::config::Config;
 use crate::lexer::{Token::*, *};
 
 static INIT: Once = Once::new();
 
 fn init_test_config() {
     INIT.call_once(|| {
-        init_config("config.toml").expect("Failed to initialize test config");
+        CONFIG.get_or_init(Config::default);
     });
 }
 

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1,4 +1,5 @@
-use crate::config::init_config;
+use crate::CONFIG;
+use crate::config::Config;
 use crate::lexer::tokenize;
 use crate::parser::{parse_block, parse_inline};
 use crate::types::{MdBlockElement::*, MdInlineElement::*, MdListItem, ToHtml};
@@ -8,7 +9,7 @@ static INIT: Once = Once::new();
 
 fn init_test_config() {
     INIT.call_once(|| {
-        init_config("config.toml").expect("Failed to initialize test config");
+        CONFIG.get_or_init(Config::default);
     });
 }
 


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I updated the way configs are checked to ensure that if a new field is added, it is properly appended to the user's `config.toml`. 

## More Details

<!-- Describe the changes made in this pull request -->

### Config
- The `Config`, `LexerConfig`, and `HtmlConfig` structs now all implement the `Default` trait.
  - There are helper functions that return the default values for `tab_size`, `css_file`, `prism_theme`, and `sanitize_html`.
  - The other fields use Rust `default()` methods for their types (we need the other functions because `serde` only allows `Callable` paths when applying defaults to fields.
-  On program start, the config will be validated against the default values for the most up-to-date `Config` definition
  - If any fields are missing, a warning is displayed and the `config.toml` file is updated with the missing fields
  - Thanks to `toml_edit`, the user's whitespace and comments will be preserved in the updated `config.toml`
  - **Note:** the order of sections (i.e. "lexer", "html") will always be written in the same order as the default config
    - However, due to a limitation of `toml_edit`, the order of the fields within each section are not preserved
    - To help this, the fields will always be written in alphabetical order

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- All tests now use `Config::default()` instead of the `init_config("config.toml")` call from before

## New Dependencies (if applicable)

<!-- List any new dependencies added in this pull request -->

- [`toml_edit v0.23.2`](https://docs.rs/toml_edit/latest/toml_edit/): Used for retaining the comments and whitespace of the original user `config.toml` file
  - I believe that theoretically this could replace the use of `toml`, however I was unable to have `toml_edit` print to the table format without it. 
  - For now I don't mind this being another dependency; perhaps later I'll experiment more with using only `toml_edit`, but for now I'll keep both.