### PR TITLE
Move to only `toml edit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,6 @@ dependencies = [
  "env_logger",
  "log",
  "serde",
- "toml",
  "toml_edit",
  "unicode-segmentation",
  "unicode_categories",
@@ -893,21 +892,6 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1dee9dc43ac2aaf7d3b774e2fba5148212bf2bd9374f4e50152ebe9afd03d42"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "toml_parser",
  "toml_writer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ dirs = "6.0.0"
 env_logger = "0.11.8"
 log = "0.4.27"
 serde = { version = "1.0", features = ["derive"] }
-toml_edit = "0.23.2"
+toml_edit = { version = "0.23.2", features = ["serde"] }
 unicode-segmentation = "1.12.0"
 unicode_categories = "0.1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ dirs = "6.0.0"
 env_logger = "0.11.8"
 log = "0.4.27"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.9.2"
 toml_edit = "0.23.2"
 unicode-segmentation = "1.12.0"
 unicode_categories = "0.1.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,7 +143,7 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
     let mut config_needs_update = false;
     let mut missing_fields = Vec::new();
     for (section, values) in filled_doc.iter() {
-        let value = values.as_table().unwrap_or_else(|| {
+        let table = values.clone().into_table().unwrap_or_else(|_item| {
             error!(
                 "Expected a table for field '{}', but found: {}",
                 section, values
@@ -151,7 +151,7 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
             panic!("Invalid configuration format for field '{}'", section);
         });
 
-        for (sub_key, sub_value) in value.iter() {
+        for (sub_key, sub_value) in table.iter() {
             if !doc.contains_key(section) {
                 doc[section] = filled_doc[section].clone();
                 config_needs_update = true;

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,10 +174,31 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
 
         // Formats the file with sections like `[lexer]` and `tab_size = 4`
         // previously it would be `lexer = { tab_size = 4 }`
-        doc["lexer"] = doc["lexer"].clone().into_table().unwrap().into();
+        if !doc["lexer"].is_table() {
+            doc["lexer"] = doc["lexer"]
+                .clone()
+                .into_table()
+                .unwrap_or_else(|_item| {
+                    error!(
+                        "Expected 'lexer' to be a table, but found: {}",
+                        doc["lexer"]
+                    );
+                    panic!("Invalid configuration format for 'lexer'");
+                })
+                .into();
+        }
         doc["lexer"].as_table_mut().unwrap().set_position(0);
 
-        doc["html"] = doc["html"].clone().into_table().unwrap().into();
+        if !doc["html"].is_table() {
+            doc["html"] = doc["html"]
+                .clone()
+                .into_table()
+                .unwrap_or_else(|_item| {
+                    error!("Expected 'html' to be a table, but found: {}", doc["html"]);
+                    panic!("Invalid configuration format for 'html'");
+                })
+                .into();
+        }
         doc["html"].as_table_mut().unwrap().sort_values();
 
         std::fs::write(file_path, doc.to_string())

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,8 +174,10 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
 
         // Formats the file with sections like `[lexer]` and `tab_size = 4`
         // previously it would be `lexer = { tab_size = 4 }`
-        doc.set_implicit(true);
+        doc["lexer"] = doc["lexer"].clone().into_table().unwrap().into();
         doc["lexer"].as_table_mut().unwrap().set_position(0);
+
+        doc["html"] = doc["html"].clone().into_table().unwrap().into();
         doc["html"].as_table_mut().unwrap().sort_values();
 
         std::fs::write(file_path, doc.to_string())

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ impl Config {
             let contents = std::fs::read_to_string(file_path)
                 .map_err(|e| format!("Failed to read config file: {}", e))?;
 
-            let config: Config = toml::from_str(&contents)
+            let config: Config = toml_edit::de::from_str(&contents)
                 .map_err(|e| format!("Failed to parse config file: {}", e))?;
 
             validate_config(file_path, contents, &config)?;
@@ -109,7 +109,7 @@ impl Config {
             let contents = std::fs::read_to_string(&config_path)
                 .map_err(|e| format!("Failed to read config file: {}", e))?;
 
-            let config: Config = toml::from_str(&contents)
+            let config: Config = toml_edit::de::from_str(&contents)
                 .map_err(|e| format!("Failed to parse config file: {}", e))?;
 
             validate_config(&config_path.to_string_lossy(), contents, &config)?;
@@ -137,11 +137,8 @@ fn validate_config(file_path: &str, contents: String, config: &Config) -> Result
     let mut doc = toml_edit::DocumentMut::from_str(&contents)
         .map_err(|e| format!("Failed to create TOML document: {}", e))?;
 
-    let filled: toml::Value = toml::Value::try_from(config)
-        .map_err(|e| format!("Failed to convert config to TOML: {}", e))?;
-
-    let filled_doc = toml_edit::Document::from_str(&toml::to_string(&filled).unwrap())
-        .map_err(|e| format!("Failed to create TOML document: {}", e))?;
+    let filled_doc = toml_edit::ser::to_document(config)
+        .map_err(|e| format!("Failed to serialize config to TOML: {}", e))?;
 
     let mut config_needs_update = false;
     let mut missing_fields = Vec::new();

--- a/src/io.rs
+++ b/src/io.rs
@@ -296,7 +296,7 @@ pub fn write_default_config(default_config: &Config) -> Result<(), String> {
         )
     })?;
 
-    let default_config_content = toml::to_string_pretty(&default_config)
+    let default_config_content = toml_edit::ser::to_string_pretty(&default_config)
         .map_err(|e| format!("Failed to serialize default config: {}", e))?;
 
     file.write_all(default_config_content.as_bytes())


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I changed from using both `toml` and `toml_edit` to just using `toml_edit`.

## More Details

<!-- Describe the changes made in this pull request -->

- `toml_edit` is now used for all `Config` related operations
- Towards the end of validating the config, a check is now in place to ensure that the output for `[lexer]` and `[html]` are in tabular format

## Dependency Update

<!-- List any new dependencies added in this pull request -->

- `toml` has been removed from the dependency list in favor of `toml_edit`
- `toml_edit` now uses the `serde` feature