### PR TITLE
Add multithreading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/mark-rs)](https://crates.io/crates/mark-rs)
 [![docs](https://img.shields.io/badge/docs-main-blue)](https://zliel.github.io/Mark-rs/markrs/index.html)
 
-Mark-rs is a 100% Commonmark-compliant Markdown parser and static site generator written in Rust.
+Mark-rs is a multithreaded, 100% Commonmark-compliant Markdown parser and static site generator written in Rust.
 It is designed to be fast, efficient, and easy to use.
 
 ## Table of Contents
@@ -26,6 +26,7 @@ It is designed to be fast, efficient, and easy to use.
 
 - Fast Markdown parsing
 - HTML generation
+- Multithreaded
 - Custom configuration
 - Easy-to-use CLI
 
@@ -98,6 +99,7 @@ You can also use the following CLI arguments to customize the behavior of Mark-r
 
 - `-c, --config <CONFIG>`: Specify a custom configuration file (default: `./config.toml`).
 - `-o, --output-dir <OUTPUT_DIR>`: Specify the output directory for the generated HTML files (default: `/output`).
+- `-n --num_threads <NUM_THREADS>`: Specify the number of threads to use (default: 4).
 - `-r, --recursive`: Recursively parse all Markdown files in the specified directory and its subdirectories. (default: false if not present)
 - `-v, --verbose`: Enable verbose output, which will print additional information while the program is running.
 - `-h, --help`: Display help information.

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     thread_pool.join_all();
 
     let index_html = generate_index(&file_names);
-    write_html_to_file(&index_html, &cli.output_dir, "index.html")?;
+    write_html_to_file(&index_html, output_dir, "index.html")?;
 
     let css_file = CONFIG.get().unwrap().html.css_file.clone();
     if css_file != "default" && !css_file.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use env_logger::Env;
 use log::{error, info};
 use std::error::Error;
 use std::path::Path;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use crate::config::{Config, init_config};
 use crate::html_generator::{generate_html, generate_index};

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,19 +99,19 @@ fn run() -> Result<(), Box<dyn Error>> {
     let index_html = generate_index(&file_names);
     write_html_to_file(&index_html, output_dir, "index.html")?;
 
-    let css_file = CONFIG.get().unwrap().html.css_file.clone();
+    let css_file = &CONFIG.get().unwrap().html.css_file;
     if css_file != "default" && !css_file.is_empty() {
         info!("Using custom CSS file: {}", css_file);
-        copy_css_to_output_dir(&css_file, &cli.output_dir)?;
+        copy_css_to_output_dir(css_file, &cli.output_dir)?;
     } else {
         info!("Using default CSS file.");
         write_default_css_file(&cli.output_dir)?;
     }
 
-    let favicon_path = CONFIG.get().unwrap().html.favicon_file.clone();
+    let favicon_path = &CONFIG.get().unwrap().html.favicon_file;
     if !favicon_path.is_empty() {
         info!("Copying favicon from: {}", favicon_path);
-        copy_favicon_to_output_dir(&favicon_path, &cli.output_dir)?;
+        copy_favicon_to_output_dir(favicon_path, &cli.output_dir)?;
     } else {
         info!("No favicon specified in config.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use crate::types::{ThreadPool, Token};
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(
     author = "Zackary Liel",
     version = "1.3.2",

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use crate::types::{ThreadPool, Token};
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
 
-#[derive(Parser, Debug, Clone)]
+#[derive(Parser, Debug)]
 #[command(
     author = "Zackary Liel",
     version = "1.3.2",

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,6 @@ fn run() -> Result<(), Box<dyn Error>> {
     let config_path = &cli.config;
     let run_recursively = &cli.recursive;
     let num_threads = cli.num_threads;
-    let output_dir = &cli.output_dir.clone();
 
     // Setup
     let env = if cli.verbose {
@@ -97,7 +96,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     thread_pool.join_all();
 
     let index_html = generate_index(&file_names);
-    write_html_to_file(&index_html, output_dir, "index.html")?;
+    write_html_to_file(&index_html, &cli.output_dir, "index.html")?;
 
     let css_file = &CONFIG.get().unwrap().html.css_file;
     if css_file != "default" && !css_file.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,8 @@ fn run() -> Result<(), Box<dyn Error>> {
         });
     }
 
+    thread_pool.join_all();
+
     let index_html = generate_index(&file_names);
     write_html_to_file(&index_html, &cli.output_dir, "index.html")?;
 
@@ -117,8 +119,8 @@ fn run() -> Result<(), Box<dyn Error>> {
 }
 
 fn generate_static_site(
-    cli: &Cli,
-    file_path: &str,
+    cli: Arc<Mutex<Cli>>,
+    file_path: &String,
     file_contents: &str,
 ) -> Result<(), Box<dyn Error>> {
     // Tokenizing

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ struct Cli {
     recursive: bool,
     #[arg(short, long, default_value = "false")]
     verbose: bool,
+    #[arg(short, long, default_value = "4")]
+    num_threads: usize,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let config_path = &cli.config;
     let run_recursively = &cli.recursive;
     let num_threads = cli.num_threads;
+    let output_dir = &cli.output_dir.clone();
 
     // Setup
     let env = if cli.verbose {
@@ -84,7 +85,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     for (file_path, file_content) in file_contents {
         info!("Generating HTML for file: {}", file_path);
         generate_static_site(&cli, &file_path, &file_content)?;
-        file_names.push(file_path);
+        file_names.push(file_path.clone());
         let cli_clone = Arc::clone(&cli);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,9 +84,13 @@ fn run() -> Result<(), Box<dyn Error>> {
     let cli = Arc::new(Mutex::new(cli));
     for (file_path, file_content) in file_contents {
         info!("Generating HTML for file: {}", file_path);
-        generate_static_site(&cli, &file_path, &file_content)?;
         file_names.push(file_path.clone());
         let cli_clone = Arc::clone(&cli);
+
+        thread_pool.execute(move || {
+            generate_static_site(cli_clone, &file_path.clone(), &file_content)
+                .unwrap_or_else(|e| error!("Failed to generate HTML for {}: {}", &file_path, e));
+        });
     }
 
     let index_html = generate_index(&file_names);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use env_logger::Env;
 use log::{error, info};
 use std::error::Error;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::config::{Config, init_config};
 use crate::html_generator::{generate_html, generate_index};
@@ -21,7 +21,7 @@ use crate::io::{
 };
 use crate::lexer::tokenize;
 use crate::parser::{group_lines_to_blocks, parse_blocks};
-use crate::types::Token;
+use crate::types::{ThreadPool, Token};
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
 
@@ -76,6 +76,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let file_contents = read_input_dir(input_dir, run_recursively)?;
     let mut file_names: Vec<String> = Vec::new();
 
+    let thread_pool = ThreadPool::build(num_threads)?;
     for (file_path, file_content) in file_contents {
         info!("Generating HTML for file: {}", file_path);
         generate_static_site(&cli, &file_path, &file_content)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,7 @@ fn generate_static_site(
     file_contents: &str,
 ) -> Result<(), Box<dyn Error>> {
     // Tokenizing
+    let cli = cli.lock().unwrap().clone();
     let mut tokenized_lines: Vec<Vec<Token>> = Vec::new();
     for line in file_contents.split('\n') {
         tokenized_lines.push(tokenize(line));

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,16 +101,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     let css_file = CONFIG.get().unwrap().html.css_file.clone();
     if css_file != "default" && !css_file.is_empty() {
         info!("Using custom CSS file: {}", css_file);
-        copy_css_to_output_dir(&css_file, &cli.output_dir)?;
+        copy_css_to_output_dir(&css_file, &cli.lock().unwrap().output_dir)?;
     } else {
         info!("Using default CSS file.");
-        write_default_css_file(&cli.output_dir)?;
+        write_default_css_file(&cli.lock().unwrap().output_dir)?;
     }
 
     let favicon_path = CONFIG.get().unwrap().html.favicon_file.clone();
     if !favicon_path.is_empty() {
         info!("Copying favicon from: {}", favicon_path);
-        copy_favicon_to_output_dir(&favicon_path, &cli.output_dir)?;
+        copy_favicon_to_output_dir(&favicon_path, &cli.lock().unwrap().output_dir)?;
     } else {
         info!("No favicon specified in config.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let input_dir = &cli.input_dir;
     let config_path = &cli.config;
     let run_recursively = &cli.recursive;
+    let num_threads = cli.num_threads;
 
     // Setup
     let env = if cli.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,10 +80,12 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut file_names: Vec<String> = Vec::new();
 
     let thread_pool = ThreadPool::build(num_threads)?;
+    let cli = Arc::new(Mutex::new(cli));
     for (file_path, file_content) in file_contents {
         info!("Generating HTML for file: {}", file_path);
         generate_static_site(&cli, &file_path, &file_content)?;
         file_names.push(file_path);
+        let cli_clone = Arc::clone(&cli);
     }
 
     let index_html = generate_index(&file_names);

--- a/src/types.rs
+++ b/src/types.rs
@@ -612,6 +612,17 @@ impl ThreadPool {
         Ok(ThreadPool { workers, sender })
     }
 
+    pub fn execute<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let job: Job = Box::new(f);
+
+        self.sender.send(job).unwrap_or_else(|e| {
+            warn!("Failed to send job to thread pool: {}", e);
+        });
+    }
+}
 
 #[derive(Debug)]
 pub struct WorkerCreationError {

--- a/src/types.rs
+++ b/src/types.rs
@@ -613,6 +613,16 @@ impl ThreadPool {
         Ok(ThreadPool { workers, sender })
     }
 
+    pub fn join_all(self) {
+        drop(self.sender); // Close the channel to signal workers to exit
+
+        for worker in self.workers {
+            if let Err(e) = worker.thread.join() {
+                warn!("Worker thread {} failed to join: {:?}", worker.id, e);
+            }
+        }
+    }
+
     pub fn execute<F>(&self, f: F)
     where
         F: FnOnce() + Send + 'static,

--- a/src/types.rs
+++ b/src/types.rs
@@ -569,6 +569,21 @@ fn is_punctuation(token: &Token) -> bool {
             | Token::CloseParenthesis
     )
 }
+
+#[derive(Debug)]
+pub struct PoolCreationError {
+    pub message: String,
+}
+
+impl std::fmt::Display for PoolCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PoolCreationError: {}", self.message)
+    }
+}
+
+
+impl Error for PoolCreationError {}
+
 pub struct ThreadPool {
     workers: Vec<Worker>,
     sender: mpsc::Sender<Job>,
@@ -596,6 +611,7 @@ impl ThreadPool {
 
         Ok(ThreadPool { workers, sender })
     }
+
 
 #[derive(Debug)]
 pub struct WorkerCreationError {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@
 //! block elements, and a cursor for navigating through tokens.
 
 use log::warn;
+use std::error::Error;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -597,8 +597,19 @@ impl ThreadPool {
         Ok(ThreadPool { workers, sender })
     }
 
+#[derive(Debug)]
+pub struct WorkerCreationError {
+    pub message: String,
 }
+
+impl std::fmt::Display for WorkerCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WorkerCreationError: {}", self.message)
+    }
 }
+
+impl Error for WorkerCreationError {}
+
 struct Worker {
     pub id: usize,
     pub thread: thread::JoinHandle<()>,


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for using multiple threads, making Mark-rs approximately 25% faster!

## More Details

<!-- Describe the changes made in this pull request -->

### Threads
- There is now a `Worker` struct that is a wrapper for threads
- There is now a `Job` type which represents a closure for `Workers` to execute
- There is now a `ThreadPool` type that keeps track of `Workers` and `Jobs`
  - Note that `ThreadPool::build()` will panic if `num_threads` in the CLI is set to 0

### CLI
- When running, before being passed to `generate_static_site()`, the CLI is wrapped in an Arc to allow it to be shared among threads
- There's a new `num_threads` flag that let's users assign the max number of threads to use
  - The default without the flag is 4

### Memory
- The `file_path` when generating the static sites for each page is now cloned because it will be moved by the `thread_pool::execute()` closure and needs to be added to the list of file names for the index
- A couple of extra clones of CONFIG attributes have been removed

### Performance Update:
I ran the same tests as before:
- I ran Mark-rs v1.3.2 and the current branch's build with `hyperfine` using  the following flags:
  - `--warmup 3`: To mimic typical use
  - `-m 1000`: Without this they would run a different number of test runs
  - `-N`: Without this flag both run about 1ms faster on average, but this mimics a fresh shell start every time
  - `--prepare "rm -rf ./test_output": To ensure the program has to rebuild the test_output directory every time

And these were the results:
<img width="1910" height="495" alt="image" src="https://github.com/user-attachments/assets/0ee267b6-1442-465a-b846-5d1aeb394d9a" />
- Mark-rs v1.3.2 (single-threaded): Averaged 11.3ms. I've seen this fluctuate up to 11.4ms and down to 11.1ms but pretty consistently it showed 11.3ms.
- This branch's release build (run with 4 threads): Averaged 8.7ms. Again I've seen it as high as 8.8ms and as low as 8.6ms but it was consistently 8.7ms.

I also noticed performance boosts up to 6 threads on my laptop, but since my laptop has 4 cores and 2 threads per core, I was somewhat surprised to see that performance dipped when using 7 or 8 threads, maybe because at that point it's forced to compete for the same resources as the other processes running on my laptop.