### PR TITLE
Improve mem usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ unicode_categories = "0.1.1"
 [[bin]]
 name = "markrs"
 path = "src/main.rs"
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -3,6 +3,7 @@
 use ammonia::clean;
 
 use crate::CONFIG;
+use crate::config::Config;
 use crate::types::{MdBlockElement, ToHtml};
 use crate::utils::build_rel_prefix;
 
@@ -26,8 +27,9 @@ pub fn generate_html(
     html_rel_path: &str,
 ) -> String {
     let mut html_output = String::new();
+    let config = CONFIG.get().unwrap();
 
-    let head = generate_head(file_name, html_rel_path);
+    let head = generate_head(file_name, html_rel_path, config);
 
     let mut body = String::from("\t<body>\n");
     body.push_str(&indent_html(&generate_navbar(html_rel_path), 2));
@@ -39,7 +41,7 @@ pub fn generate_html(
         .collect::<Vec<String>>()
         .join("\n");
 
-    let inner_html = if CONFIG.get().unwrap().html.sanitize_html {
+    let inner_html = if config.html.sanitize_html {
         ammonia::Builder::default()
             .add_tag_attributes("a", &["href", "title", "target"])
             .add_tag_attribute_values("a", "target", &["_blank", "_self"])
@@ -66,7 +68,7 @@ pub fn generate_html(
     body.push_str(&indent_html(&inner_html, 3));
     body.push_str("\n\t\t</div>");
 
-    if CONFIG.get().unwrap().html.use_prism {
+    if config.html.use_prism {
         body.push_str(
             "\n\n\t\t<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/components/prism-core.min.js\" integrity=\"sha512-Uw06iFFf9hwoN77+kPl/1DZL66tKsvZg6EWm7n6QxInyptVuycfrO52hATXDRozk7KWeXnrSueiglILct8IkkA==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>",
         );
@@ -98,7 +100,7 @@ pub fn generate_html(
 pub fn generate_index(file_names: &[String]) -> String {
     let mut html_output = String::new();
 
-    let head = generate_head("index", "index.html");
+    let head = generate_head("index", "index.html", CONFIG.get().unwrap());
 
     let mut body = String::from("\t<body>\n");
     body.push_str(&generate_navbar("index.html"));
@@ -128,8 +130,7 @@ pub fn generate_index(file_names: &[String]) -> String {
 /// * `file_name` - The name of the markdown file, used to set the title of the HTML document.
 /// * `html_rel_path` - The relative path to the HTML file from the output directory, used for
 ///   linking
-fn generate_head(file_name: &str, html_rel_path: &str) -> String {
-    let config = CONFIG.get().unwrap();
+fn generate_head(file_name: &str, html_rel_path: &str, config: &Config) -> String {
     let mut head = String::from(
         r#"<!DOCTYPE html>
     <html lang="en">

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -217,8 +217,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 /// assert!(is_punctuation("$"));
 /// ```
 fn is_punctuation(input_str: &str) -> bool {
-    let ch = input_str.chars().next().unwrap_or_default();
-    input_str.chars().count() == 1 && (ch.is_punctuation() || ch.is_symbol_currency())
+    if let Some(ch) = input_str.chars().next() {
+        ch.is_punctuation() || ch.is_symbol_currency()
+    } else {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,8 @@
 //! This module provides functionality to tokenize a line of markdown text into a vector of `Token`
 //! enums.
 
+use std::mem::take;
+
 use crate::CONFIG;
 use crate::types::Token;
 use crate::utils::push_buffer_to_collection;
@@ -131,8 +133,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 if i + 1 < str_len && chars[i + 1] == ">" {
                     buffer.push_str(chars[i]);
                     buffer.push_str(chars[i + 1]);
-                    tokens.push(Token::RawHtmlTag(buffer.clone()));
-                    buffer.clear();
+                    tokens.push(Token::RawHtmlTag(take(&mut buffer)));
                     i += 1;
                 } else {
                     buffer.push_str(chars[i]);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -146,7 +146,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                     if i == 0 || tokens.last() == Some(&Token::Tab) {
                         push_buffer_to_collection(&mut tokens, &mut buffer);
                         tokens.push(Token::OrderedListMarker(chars[i].to_owned() + chars[i + 1]));
-                        // tokens.push(Token::Whitespace);
+
                         i += 2;
                         continue;
                     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -353,10 +353,8 @@ impl ToHtml for MdInlineElement {
                 title,
                 url,
             } => {
-                let mut media_url = url.clone();
-
                 // If the image uses a relative path, copy it to the output directory
-                if !url.starts_with("http") {
+                let media_url = if !url.starts_with("http") {
                     if let Err(e) = copy_image_to_output_dir(url, output_dir, input_dir) {
                         warn!("Unable to copy image {url}: {e}");
                     }
@@ -366,8 +364,10 @@ impl ToHtml for MdInlineElement {
 
                     let rel_prefix = build_rel_prefix(html_rel_path);
 
-                    media_url = format!("./{}/media/{}", rel_prefix.to_string_lossy(), url);
-                }
+                    &format!("./{}/media/{}", rel_prefix.to_string_lossy(), url)
+                } else {
+                    url
+                };
 
                 match title {
                     Some(text) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    mem::take,
+    path::{Path, PathBuf},
+};
 
 /// Utility function for pushing a String buffer to a generic collection.
 ///
@@ -17,8 +20,7 @@ where
     T: From<String>,
 {
     if !buffer.is_empty() {
-        collection.push(T::from(buffer.to_string()));
-        buffer.clear();
+        collection.push(T::from(take(buffer)));
     }
 }
 


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I did some more memory and performance optimization, and updated the release profile to use `lto` and `codegen-units = 1`

## More Details

<!-- Describe the changes made in this pull request -->

### Memory
- Many calls to `clone()` and `clear()` were replaced with `std::mem::take`
- Some extra calls to `CONFIG.get().unwrap()` were moved into a single call at the top of functions

### Release Profile
- The release profile now uses `lto = true` (so "fat" LTO) to optimize for speed
- The release profile now uses `codegen-units = 1`
  - These both increase the compile time, but result in faster execution. Since this project only takes about 20 seconds to compile even with these settings, I think this is acceptable for this project, especially considering the resulting boost in performance
 
### Performance Update
I have finally figured out how to use `hyperfine` more effectively! I completely missed the fact that you're supposed to run two commands in the same line and then `hyperfine` compares them for you, so I fixed that! I also found out that you can specify the exact number of runs to use by using both `-m` and `-M`, so tests will always run exactly 1000 cycles. 

This test was still run against v1.3.2 (which is single-threaded), but future tests will be against v1.3.3 using the same number of threads.

However, with all of these changes, v1.3.3 is already about 57% faster than v1.3.2! See the screenshot below for the test results. I believe there is a bit more speed to be gained by putting the index creation and css copying into threads as well, so that's the next thing I'll be looking into. I also noticed a slight improvement even when using Mark-rs single-threaded, going from v1.3.2's 11.3ms to this PR's 9.9ms!

### Binary Size
The profile options also decreased the size of the release binary, from v1.3.2's 5.0MB to this PR's 4.1MB. 
## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->
<img width="1906" height="271" alt="image" src="https://github.com/user-attachments/assets/4eec8161-2d50-4b5b-bb4d-b568e388c0a4" />

