### PR TITLE
Add index and copies to threads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -261,3 +261,14 @@ impl From<toml_edit::de::Error> for Error {
         Error::TomlDeserialization(err)
     }
 }
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Toml(e) => Some(e),
+            Error::TomlSerialization(e) => Some(e),
+            Error::TomlDeserialization(e) => Some(e),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,3 +38,13 @@ impl From<thread_pool::Error> for Error {
         Error::ThreadPool(error)
     }
 }
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Config(e) => Some(e),
+            Error::ThreadPool(e) => Some(e),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,8 @@ fn run() -> Result<(), Error> {
         info!("No favicon specified in config.");
     }
 
+    thread_pool.join_all();
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ fn run() -> Result<(), Error> {
     env_logger::Builder::from_env(env).init();
 
     init_config(config_path)?;
+    let config = CONFIG.get().unwrap();
     let file_contents = read_input_dir(input_dir, run_recursively)?;
     let mut file_names: Vec<String> = Vec::with_capacity(file_contents.len());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,13 +93,15 @@ fn run() -> Result<(), Error> {
         info!("Generating HTML for file: {}", file_path);
 
         file_names.push(file_path.clone());
-        let cli_clone = Arc::clone(&cli);
 
         thread_pool
-            .execute(move || {
-                generate_static_site(cli_clone, &file_path, &file_content).unwrap_or_else(|e| {
-                    error!("Failed to generate HTML for {}: {}", &file_path, e)
-                });
+            .execute({
+                let cli = Arc::clone(&cli);
+                move || {
+                    generate_static_site(cli, &file_path, &file_content).unwrap_or_else(|e| {
+                        error!("Failed to generate HTML for {}: {}", &file_path, e)
+                    });
+                }
             })
             .map_err(|e| {
                 error!("Failed to execute job in thread pool: {}", e);

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -112,3 +112,5 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added the functions for generating the `index.html` file and copying over CSS and favicon files into threads.

## More Details

<!-- Describe the changes made in this pull request -->

- In addition to the above, some clones of CLI have been removed and replaced with `Arc::clone(&cli);` calls
- In `run()`, a couple of calls to `CONFIG.get().unwrap()` were moved into a single variable