### PR TITLE
Add support for links to headings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -211,7 +211,7 @@ fn validate_config(file_path: &str, contents: &str, config: &Config) -> Result<(
 pub fn init_config(config_path: &str) -> Result<(), Error> {
     CONFIG.get_or_init(|| {
         Config::from_file(config_path).unwrap_or_else(|err| {
-            error!("Failed to load config: {}", err);
+            error!("Failed to load config: {err}");
             std::process::exit(1);
         })
     });
@@ -230,10 +230,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Io(e) => write!(f, "I/O error: {}", e),
-            Error::Toml(e) => write!(f, "TOML error: {}", e),
-            Error::TomlSerialization(e) => write!(f, "TOML serialization error: {}", e),
-            Error::TomlDeserialization(e) => write!(f, "TOML deserialization error: {}", e),
+            Error::Io(e) => write!(f, "I/O error: {e}"),
+            Error::Toml(e) => write!(f, "TOML error: {e}"),
+            Error::TomlSerialization(e) => write!(f, "TOML serialization error: {e}"),
+            Error::TomlDeserialization(e) => write!(f, "TOML deserialization error: {e}"),
         }
     }
 }

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -42,7 +42,8 @@ pub fn generate_html(
         .join("\n");
 
     let inner_html = if config.html.sanitize_html {
-        ammonia::Builder::default()
+        let mut builder = ammonia::Builder::default();
+        builder
             .add_tag_attributes("a", &["href", "title", "target"])
             .add_tag_attribute_values("a", "target", &["_blank", "_self"])
             .add_tag_attributes("pre", &["class"])
@@ -58,9 +59,9 @@ pub fn generate_html(
                     "frameborder",
                     "allowfullscreen",
                 ],
-            )
-            .clean(&inner_html)
-            .to_string()
+            );
+
+        builder.clean(&inner_html).to_string()
     } else {
         inner_html
     };

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -60,6 +60,9 @@ pub fn generate_html(
                     "allowfullscreen",
                 ],
             );
+        for tag in &["h1", "h2", "h3", "h4", "h5", "h6"] {
+            builder.add_tag_attributes(tag, &["id"]);
+        }
 
         builder.clean(&inner_html).to_string()
     } else {

--- a/src/io.rs
+++ b/src/io.rs
@@ -43,7 +43,7 @@ pub fn read_input_dir(
         Ok(file_contents)
     } else {
         let entries: ReadDir = read_dir(input_dir).map_err(|e| {
-            error!("Failed to read input directory '{}': {}", input_dir, e);
+            error!("Failed to read input directory '{input_dir}': {e}");
             e
         })?;
 
@@ -98,7 +98,7 @@ fn visit_dir(
         } else if path.extension().and_then(|s| s.to_str()) == Some("md") {
             let rel_path = path
                 .strip_prefix(base)
-                .map_err(|e| io::Error::other(format!("Failed to strip base path: {}", e)))?
+                .map_err(|e| io::Error::other(format!("Failed to strip base path: {e}")))?
                 .to_string_lossy()
                 .to_string();
             let contents = read_file(path.to_str().unwrap()).map_err(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
             Ok(())
         }
         Err(e) => {
-            error!("An error occurred: {}", e);
+            error!("An error occurred: {e}");
             std::process::exit(1);
         }
     }
@@ -84,7 +84,7 @@ fn run() -> Result<(), Error> {
     let mut file_names: Vec<String> = Vec::with_capacity(file_contents.len());
 
     let thread_pool = ThreadPool::build(num_threads).map_err(|e| {
-        error!("Failed to create thread pool: {}", e);
+        error!("Failed to create thread pool: {e}");
         e
     })?;
     let cli = Arc::new(cli);
@@ -99,12 +99,12 @@ fn run() -> Result<(), Error> {
                 let cli = Arc::clone(&cli);
                 move || {
                     generate_static_site(cli, &file_path, &file_content).unwrap_or_else(|e| {
-                        error!("Failed to generate HTML for {}: {}", &file_path, e)
+                        error!("Failed to generate HTML for {file_path}: {e}");
                     });
                 }
             })
             .map_err(|e| {
-                error!("Failed to execute job in thread pool: {}", e);
+                error!("Failed to execute job in thread pool: {e}");
                 e
             })?;
     }
@@ -116,16 +116,13 @@ fn run() -> Result<(), Error> {
                 let index_html = generate_index(&file_names);
                 write_html_to_file(&index_html, &cli.output_dir, "index.html").unwrap_or_else(
                     |e| {
-                        error!("Failed to write index.html: {}", e);
+                        error!("Failed to write index.html: {e}");
                     },
                 );
             }
         })
         .map_err(|e| {
-            error!(
-                "Failed to execute job in thread pool for index generation: {}",
-                e
-            );
+            error!("Failed to execute job in thread pool for index generation: {e}");
             e
         })?;
 
@@ -137,15 +134,12 @@ fn run() -> Result<(), Error> {
                 let cli = Arc::clone(&cli);
                 move || {
                     copy_css_to_output_dir(css_file, &cli.output_dir).unwrap_or_else(|e| {
-                        error!("Failed to copy CSS file: {}", e);
+                        error!("Failed to copy CSS file: {e}");
                     });
                 }
             })
             .map_err(|e| {
-                error!(
-                    "Failed to execute job in thread pool for copying CSS file: {}",
-                    e
-                );
+                error!("Failed to execute job in thread pool for copying CSS file: {e}");
                 e
             })?;
     } else {
@@ -156,15 +150,12 @@ fn run() -> Result<(), Error> {
                 let cli = Arc::clone(&cli);
                 move || {
                     write_default_css_file(&cli.output_dir).unwrap_or_else(|e| {
-                        error!("Failed to write default CSS file: {}", e);
+                        error!("Failed to write default CSS file: {e}");
                     });
                 }
             })
             .map_err(|e| {
-                error!(
-                    "Failed to execute job in thread pool for using default CSS: {}",
-                    e
-                );
+                error!("Failed to execute job in thread pool for using default CSS: {e}");
                 e
             })?;
     }
@@ -177,15 +168,12 @@ fn run() -> Result<(), Error> {
                 let cli = Arc::clone(&cli);
                 move || {
                     copy_favicon_to_output_dir(favicon_path, &cli.output_dir).unwrap_or_else(|e| {
-                        error!("Failed to copy favicon: {}", e);
+                        error!("Failed to copy favicon: {e}");
                     });
                 }
             })
             .map_err(|e| {
-                error!(
-                    "Failed to execute job in thread pool for favicon copy: {}",
-                    e
-                );
+                error!("Failed to execute job in thread pool for favicon copy: {e}");
                 e
             })?;
     } else {

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1981,7 +1981,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "\n<h1 id=\"this-is-a-heading-with-strongbold-textstrong-and-emitalic-textem\">This is a heading with <strong>bold text</strong> and <em>italic text</em>.</h1>\n<div>Some raw HTML content</div>\n"
+                "\n<h1 id=\"this-is-a-heading-with-bold-text-and-italic-text\">This is a heading with <strong>bold text</strong> and <em>italic text</em>.</h1>\n<div>Some raw HTML content</div>\n"
             );
         }
 

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1766,7 +1766,7 @@ mod html_generation {
                     .iter()
                     .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                     .collect::<String>(),
-                "\n<h1>Heading 1</h1>\n"
+                "\n<h1 id=\"heading-1\">Heading 1</h1>\n"
             );
         }
 
@@ -1778,7 +1778,7 @@ mod html_generation {
                     .iter()
                     .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                     .collect::<String>(),
-                "\n<h3>Heading 3</h3>\n"
+                "\n<h3 id=\"heading-3\">Heading 3</h3>\n"
             );
         }
 
@@ -1790,7 +1790,7 @@ mod html_generation {
                     .iter()
                     .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                     .collect::<String>(),
-                "\n<h2>Heading 2 with <b>bold words</b></h2>\n"
+                "\n<h2 id=\"heading-2-with-bold-words\">Heading 2 with <b>bold words</b></h2>\n"
             );
         }
 
@@ -1934,7 +1934,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<blockquote>\n<p>This is a blockquote with a nested heading:</p>\n<h1>Heading 1</h1>\n\n</blockquote>"
+                "<blockquote>\n<p>This is a blockquote with a nested heading:</p>\n<h1 id=\"heading-1\">Heading 1</h1>\n\n</blockquote>"
             );
         }
 
@@ -1969,6 +1969,9 @@ mod html_generation {
 
         #[test]
         fn mixed_markdown_and_html() {
+            // Note that this heading's id is abnormal because RawHtml Tokens don't store the
+            // token content between tags, only the content of the tags themselves.
+            // This is only a problem if headings contain raw html.
             init_test_config();
             assert_eq!(
                 parse_blocks(&group_lines_to_blocks(vec![
@@ -1978,7 +1981,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "\n<h1>This is a heading with <strong>bold text</strong> and <em>italic text</em>.</h1>\n<div>Some raw HTML content</div>\n"
+                "\n<h1 id=\"this-is-a-heading-with-strongbold-textstrong-and-emitalic-textem\">This is a heading with <strong>bold text</strong> and <em>italic text</em>.</h1>\n<div>Some raw HTML content</div>\n"
             );
         }
 

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -51,9 +51,9 @@ impl ThreadPool {
         let job: Job = Box::new(f);
 
         self.sender.send(job).map_err(|e| {
-            warn!("Failed to send job to thread pool: {}", e);
+            warn!("Failed to send job to thread pool: {e}");
             Error::JobExecution {
-                message: format!("Failed to send job to thread pool: {}", e),
+                message: format!("Failed to send job to thread pool: {e}"),
             }
         })
     }
@@ -87,7 +87,7 @@ impl Worker {
                 }
             })
             .map_err(|e| Error::WorkerCreation {
-                message: format!("Failed to spawn thread {}: {}", id, e),
+                message: format!("Failed to spawn thread {id}: {e}"),
             })?;
 
         Ok(Worker { id, thread })
@@ -106,9 +106,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::PoolCreation { message } => write!(f, "Thread pool creation error: {}", message),
-            Error::JobExecution { message } => write!(f, "Job execution error: {}", message),
-            Error::WorkerCreation { message } => write!(f, "Worker creation error: {}", message),
+            Error::PoolCreation { message } => write!(f, "Thread pool creation error: {message}"),
+            Error::JobExecution { message } => write!(f, "Job execution error: {message}"),
+            Error::WorkerCreation { message } => write!(f, "Worker creation error: {message}"),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -82,7 +82,20 @@ impl ToHtml for MdBlockElement {
                     .map(|el| el.to_html(output_dir, input_dir, html_rel_path))
                     .collect::<String>();
 
-                format!("\n<h{level}>{inner_html}</h{level}>\n")
+                let id = content
+                    .iter()
+                    .map(MdInlineElement::to_plain_text)
+                    .collect::<String>()
+                    .to_lowercase()
+                    .replace([' ', '_'], "-")
+                    .replace(
+                        [
+                            '<', '>', '/', '\\', '"', '\'', '&', '`', ',', '?', '!', '.', ':', ';',
+                        ],
+                        "",
+                    );
+
+                format!("\n<h{level} id=\"{id}\">{inner_html}</h{level}>\n")
             }
             MdBlockElement::Paragraph { content } => {
                 let inner_html = content

--- a/src/types.rs
+++ b/src/types.rs
@@ -185,6 +185,7 @@ impl ToHtml for MdBlockElement {
     }
 }
 
+/// Cleans the ID string by removing HTML tags and special characters, and replacing spaces and underscores with hyphens.
 fn clean_id(old_id: String) -> String {
     let mut new_id = String::new();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -85,15 +85,10 @@ impl ToHtml for MdBlockElement {
                 let id = content
                     .iter()
                     .map(MdInlineElement::to_plain_text)
-                    .collect::<String>()
-                    .to_lowercase()
-                    .replace([' ', '_'], "-")
-                    .replace(
-                        [
-                            '<', '>', '/', '\\', '"', '\'', '&', '`', ',', '?', '!', '.', ':', ';',
-                        ],
-                        "",
-                    );
+                    .collect::<String>();
+
+                let id = clean_id(id);
+                println!("Header ID: {id}");
 
                 format!("\n<h{level} id=\"{id}\">{inner_html}</h{level}>\n")
             }
@@ -188,6 +183,30 @@ impl ToHtml for MdBlockElement {
             }
         }
     }
+}
+
+fn clean_id(old_id: String) -> String {
+    let mut new_id = String::new();
+
+    let mut in_tag = false;
+    for char in old_id.chars() {
+        if char == '<' {
+            in_tag = true;
+        } else if char == '>' {
+            in_tag = false;
+            continue;
+        }
+
+        if !in_tag && (char.is_alphanumeric() || char == '_' || char == ' ') {
+            new_id.push(char);
+        }
+    }
+
+    new_id
+        .replace([' ', '_'], "-")
+        .to_lowercase()
+        .trim_matches('-')
+        .to_string()
 }
 
 /// Represents a list item in markdown, which can contain block elements.

--- a/src/types.rs
+++ b/src/types.rs
@@ -395,6 +395,33 @@ impl ToHtml for MdInlineElement {
     }
 }
 
+impl MdInlineElement {
+    /// Converts the inline element to a plain text representation.
+    pub fn to_plain_text(&self) -> String {
+        match self {
+            MdInlineElement::Text { content } => content.clone(),
+            MdInlineElement::Bold { content } => content
+                .iter()
+                .map(MdInlineElement::to_plain_text)
+                .collect::<Vec<_>>()
+                .join(""),
+            MdInlineElement::Italic { content } => content
+                .iter()
+                .map(MdInlineElement::to_plain_text)
+                .collect::<Vec<_>>()
+                .join(""),
+            MdInlineElement::Link { text, .. } => text
+                .iter()
+                .map(MdInlineElement::to_plain_text)
+                .collect::<Vec<_>>()
+                .join(""),
+            MdInlineElement::Image { alt_text, .. } => alt_text.clone(),
+            MdInlineElement::Code { content } => content.clone(),
+            MdInlineElement::Placeholder => unreachable!(),
+        }
+    }
+}
+
 /// Cursor for navigating through a vector of tokens
 ///
 /// This struct provides methods to access the current token, peek ahead or behind, and advance the


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added IDs to headings that match their text, allowing for links to headings (i.e. `[link](#heading-1)`). As a result, tables of contents for pages are now supported!

## More Details

<!-- Describe the changes made in this pull request -->

- IDs are added to Headings, with some notes:
  - IDs are in kebab-case and are all lowercase
  - Any raw html is filtered, but text between tags is left in
  - If inline markdown elements are present, the text of the element is added
- There's now a `clean_id()` helper function to convert the text of headings into IDs
- Some log calls have been cleaned up to use `format!("{e}")` instead of `format!("{}", e)`

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- Tests now reflect the new ID specification