### PR TITLE
Add support for longer ordered lists

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -140,22 +140,22 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 }
             }
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
-                // Check for valid ordered list marker
-                if i + 2 < str_len && chars[i + 1] == "." && chars[i + 2] == " " {
-                    // Check if the line STARTS with a number followed by a dot and space
-                    if i == 0 || tokens.last() == Some(&Token::Tab) {
-                        push_buffer_to_collection(&mut tokens, &mut buffer);
-                        tokens.push(Token::OrderedListMarker(chars[i].to_owned() + chars[i + 1]));
+                let mut marker = String::from(chars[i]);
+                while i + 1 < str_len && chars[i + 1].chars().next().unwrap().is_ascii_digit() {
+                    i += 1;
+                    marker.push_str(chars[i]);
+                }
 
-                        i += 2;
-                        continue;
-                    } else {
-                        // If the line does not start with a number followed by a dot and space,
-                        // treat it as a regular text token
-                        buffer.push_str(chars[i]);
-                    }
+                if i + 1 < str_len && chars[i + 1] != "." {
+                    buffer.push_str(&marker);
+                } else if i + 2 < str_len && chars[i + 2] == " " {
+                    push_buffer_to_collection(&mut tokens, &mut buffer);
+                    tokens.push(Token::OrderedListMarker(marker));
+
+                    i += 2;
+                    continue;
                 } else {
-                    buffer.push_str(chars[i]);
+                    buffer.push_str(&marker);
                 }
             }
             "\t" => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -227,6 +227,11 @@ fn parse_blockquote(line: &[Token]) -> MdBlockElement {
 /// # Returns
 /// An `MdBlockElement` representing the ordered list.
 fn parse_ordered_list(list: &[Token]) -> MdBlockElement {
+    let starting_num = if let Some(Token::OrderedListMarker(num)) = list.first() {
+        num.parse::<usize>().unwrap_or(1)
+    } else {
+        1
+    };
     parse_list(
         list,
         |tokens| {
@@ -235,7 +240,10 @@ fn parse_ordered_list(list: &[Token]) -> MdBlockElement {
                 Some(Token::OrderedListMarker(_)) if tokens.get(1) == Some(&Token::Whitespace)
             )
         },
-        |items| MdBlockElement::OrderedList { items },
+        |items| MdBlockElement::OrderedList {
+            items,
+            starting_num,
+        },
     )
 }
 

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -770,6 +770,7 @@ mod block {
                 tokenize("4. ![Image Item 4](http://example.com/image.png)"),
             ])),
             vec![OrderedList {
+                starting_num: 1,
                 items: vec![
                     MdListItem {
                         content: Paragraph {
@@ -823,6 +824,7 @@ mod block {
                 tokenize("2. Second")
             ])),
             vec![OrderedList {
+                starting_num: 1,
                 items: vec![
                     MdListItem {
                         content: Paragraph {
@@ -854,6 +856,7 @@ mod block {
                 tokenize("2. Item 2")
             ])),
             vec![OrderedList {
+                starting_num: 1,
                 items: vec![
                     MdListItem {
                         content: Paragraph {
@@ -864,6 +867,7 @@ mod block {
                     },
                     MdListItem {
                         content: OrderedList {
+                            starting_num: 1,
                             items: vec![
                                 MdListItem {
                                     content: Paragraph {
@@ -895,6 +899,36 @@ mod block {
     }
 
     #[test]
+    fn ordered_list_with_different_starting_num() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(&group_lines_to_blocks(vec![
+                tokenize("5. Fifth Item"),
+                tokenize("6. Sixth Item")
+            ])),
+            vec![OrderedList {
+                starting_num: 5,
+                items: vec![
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Fifth Item")
+                            }]
+                        }
+                    },
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Sixth Item")
+                            }]
+                        }
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
     fn ordered_list_with_inlines() {
         init_test_config();
         assert_eq!(
@@ -905,6 +939,7 @@ mod block {
                 tokenize("4. ![Image Item 4](http://example.com/image.png \"Some title\")"),
             ])),
             vec![OrderedList {
+                starting_num: 1,
                 items: vec![
                     MdListItem {
                         content: Paragraph {
@@ -1871,7 +1906,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<ol>\n\t<li>\n\t\t<p>First</p>\n\t</li>\n\t<li>\n\t\t<p>Second</p>\n\t</li>\n</ol>"
+                "<ol start=\"1\">\n\t<li>\n\t\t<p>First</p>\n\t</li>\n\t<li>\n\t\t<p>Second</p>\n\t</li>\n</ol>"
             );
         }
 
@@ -1888,7 +1923,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<ol>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ol>\n\t<li>\n\t\t<p>Nested Item 1.1</p>\n\t</li>\n\t<li>\n\t\t<p>Nested Item 1.2</p>\n\t</li>\n\n\t</ol><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ol>"
+                "<ol start=\"1\">\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ol>\n\t<li>\n\t\t<p>Nested Item 1.1</p>\n\t</li>\n\t<li>\n\t\t<p>Nested Item 1.2</p>\n\t</li>\n\n\t</ol><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ol>"
             );
         }
 
@@ -1905,7 +1940,22 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<ol>\n\t<li>\n\t\t<p><b>Bold Item 1</b></p>\n\t</li>\n\t<li>\n\t\t<p><i>Italic Item 2</i></p>\n\t</li>\n\t<li>\n\t\t<p><a href=\"http://example.com\" target=\"_blank\">Link Item 3⮺</a></p>\n\t</li>\n\t<li>\n\t\t<p><img src=\"http://example.com/image.png\" alt=\"Image Item 4\" title=\"Some title\"/></p>\n\t</li>\n</ol>"
+                "<ol start=\"1\">\n\t<li>\n\t\t<p><b>Bold Item 1</b></p>\n\t</li>\n\t<li>\n\t\t<p><i>Italic Item 2</i></p>\n\t</li>\n\t<li>\n\t\t<p><a href=\"http://example.com\" target=\"_blank\">Link Item 3⮺</a></p>\n\t</li>\n\t<li>\n\t\t<p><img src=\"http://example.com/image.png\" alt=\"Image Item 4\" title=\"Some title\"/></p>\n\t</li>\n</ol>"
+            );
+        }
+
+        #[test]
+        fn ordered_list_with_different_starting_num() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(&group_lines_to_blocks(vec![
+                    tokenize("5. Item 5"),
+                    tokenize("6. Item 6")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<ol start=\"5\">\n\t<li>\n\t\t<p>Item 5</p>\n\t</li>\n\t<li>\n\t\t<p>Item 6</p>\n\t</li>\n</ol>"
             );
         }
 

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1923,7 +1923,7 @@ mod html_generation {
                 .iter()
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
-                "<ol start=\"1\">\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ol>\n\t<li>\n\t\t<p>Nested Item 1.1</p>\n\t</li>\n\t<li>\n\t\t<p>Nested Item 1.2</p>\n\t</li>\n\n\t</ol><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ol>"
+                "<ol start=\"1\">\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ol start=\"1\">\n\t<li>\n\t\t<p>Nested Item 1.1</p>\n\t</li>\n\t<li>\n\t\t<p>Nested Item 1.2</p>\n\t</li>\n\n\t</ol><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ol>"
             );
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,7 @@ pub enum MdBlockElement {
         items: Vec<MdListItem>,
     },
     OrderedList {
+        starting_num: usize,
         items: Vec<MdListItem>,
     },
     Table {
@@ -88,7 +89,6 @@ impl ToHtml for MdBlockElement {
                     .collect::<String>();
 
                 let id = clean_id(id);
-                println!("Header ID: {id}");
 
                 format!("\n<h{level} id=\"{id}\">{inner_html}</h{level}>\n")
             }
@@ -130,7 +130,10 @@ impl ToHtml for MdBlockElement {
                 let inner_items = indent_html(&inner_items, 1);
                 format!("<ul>\n{inner_items}\n</ul>")
             }
-            MdBlockElement::OrderedList { items } => {
+            MdBlockElement::OrderedList {
+                items,
+                starting_num,
+            } => {
                 let inner_items = items
                     .iter()
                     .map(|item| item.to_html(output_dir, input_dir, html_rel_path))
@@ -230,7 +233,10 @@ impl ToHtml for MdListItem {
                 let inner_items = indent_html(&inner_items, 1);
                 format!("<ul>\n{inner_items}\n</ul>")
             }
-            MdBlockElement::OrderedList { items } => {
+            MdBlockElement::OrderedList {
+                items,
+                starting_num,
+            } => {
                 let inner_items = items
                     .iter()
                     .map(|item| item.to_html(output_dir, input_dir, html_rel_path))

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,7 +140,7 @@ impl ToHtml for MdBlockElement {
                     .collect::<String>();
 
                 let inner_items = indent_html(&inner_items, 1);
-                format!("<ol>\n{inner_items}\n</ol>")
+                format!("<ol start=\"{starting_num}\">\n{inner_items}\n</ol>")
             }
             MdBlockElement::Table { headers, body } => {
                 let header_html = headers
@@ -241,7 +241,7 @@ impl ToHtml for MdListItem {
                     .iter()
                     .map(|item| item.to_html(output_dir, input_dir, html_rel_path))
                     .collect::<String>();
-                format!("<ol>\n{inner_items}\n</ol>")
+                format!("<ol start=\"{starting_num}\">\n{inner_items}\n</ol>")
             }
             _ => {
                 let inner_html = indent_html(


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for ordered lists that extend beyond 9 elements, and added support for lists that start with numbers other than 1.

## More Details

<!-- Describe the changes made in this pull request -->

- Previously, list elements starting with "10. " and higher would become paragraphs rather than ordered list elements. Now they;'ll be properly parsed as list elements
- `MdBlockElement::OrderedList` elements now have a `starting_num` field that is used to set the `start` attribute in the resulting ordered list HTML elements

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- Tests now reflect the new `starting_num` field
- I added tests for lists starting with numbers other than 1