### PR TITLE
Add support for asterisk lists

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -40,7 +40,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
     let mut i = 0;
     while i < str_len {
         match chars[i] {
-            "*" if i == 0 && i + 1 < str_len && chars[i + 1] == " " => {
+            "*" if (i == 0 && matches!(chars.get(i + 1), Some(&" ")))
+                || (i > 0
+                    && matches!(chars.get(i - 1), Some(&" ") | Some(&"\t"))
+                    && matches!(chars.get(i + 1), Some(&" "))) =>
+            {
                 push_buffer_to_collection(&mut tokens, &mut buffer);
 
                 // Start of unordered list

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -40,6 +40,12 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
     let mut i = 0;
     while i < str_len {
         match chars[i] {
+            "*" if i == 0 && i + 1 < str_len && chars[i + 1] == " " => {
+                push_buffer_to_collection(&mut tokens, &mut buffer);
+
+                // Start of unordered list
+                tokens.push(Token::Punctuation(String::from(chars[i])));
+            }
             "*" | "_" => {
                 // if the current buffer isn't empty, append a Text token to the Vec<Token>
                 push_buffer_to_collection(&mut tokens, &mut buffer);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,7 +49,7 @@ fn parse_block(line: &[Token]) -> Option<MdBlockElement> {
         Some(Token::Punctuation(string)) if string == "-" || string == "*" => {
             // Note that setext headings have already been handled in the group_lines_to_blocks
             // function by this point
-            if line.len() == 1 {
+            if line.len() == 1 && string == "-" {
                 // If the line only contains a dash, then it is a thematic break
                 Some(MdBlockElement::ThematicBreak)
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,7 +46,7 @@ fn parse_block(line: &[Token]) -> Option<MdBlockElement> {
 
     match first_token {
         Some(Token::Punctuation(string)) if string == "#" => Some(parse_heading(line)),
-        Some(Token::Punctuation(string)) if string == "-" => {
+        Some(Token::Punctuation(string)) if string == "-" || string == "*" => {
             // Note that setext headings have already been handled in the group_lines_to_blocks
             // function by this point
             if line.len() == 1 {
@@ -260,7 +260,7 @@ fn parse_unordered_list(list: &[Token]) -> MdBlockElement {
     parse_list(
         list,
         |tokens| {
-            matches!(tokens.first(), Some(Token::Punctuation(string)) if string == "-" && tokens.get(1) == Some(&Token::Whitespace)
+            matches!(tokens.first(), Some(Token::Punctuation(string)) if (string == "-" || string == "*") && tokens.get(1) == Some(&Token::Whitespace)
             )
         },
         |items| MdBlockElement::UnorderedList { items },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1352,7 +1352,8 @@ fn group_tabbed_lines(
             let previous_line_start = previous_block.first();
             match previous_line_start {
                 Some(Token::Punctuation(string))
-                    if string == "-" && previous_block.get(1) == Some(&Token::Whitespace) =>
+                    if (string == "-" || string == "*")
+                        && previous_block.get(1) == Some(&Token::Whitespace) =>
                 {
                     // If the previous block is a list, then we append the line to it
                     attach_to_previous_block(blocks, previous_block, line, Some(Token::Newline));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1067,6 +1067,9 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
             Some(Token::Punctuation(string)) if string == "-" => {
                 group_dashed_lines(&mut blocks, &mut current_block, &mut previous_block, line);
             }
+            Some(Token::Punctuation(string)) if string == "*" => {
+                group_asterisked_lines(&mut blocks, &mut current_block, &mut previous_block, line);
+            }
             Some(Token::Tab) => {
                 group_tabbed_lines(&mut blocks, &mut current_block, &mut previous_block, line);
             }
@@ -1500,6 +1503,33 @@ fn group_dashed_lines(
                     blocks.push(take(previous_block));
                 }
             }
+        }
+    } else {
+        current_block.extend_from_slice(line);
+    }
+}
+
+/// Groups lines that start with asterisks into blocks.
+///
+/// # Arguments
+/// * `blocks` - A mutable reference to a vector of blocks, where each block is a vector of tokens.
+/// * `current_block` - A mutable reference to the current block being processed.
+/// * `previous_block` - A mutable reference to the previous block, used for context.
+/// * `line` - A mutable reference to the current line being processed, which is a vector of
+///   tokens.
+fn group_asterisked_lines(
+    blocks: &mut Vec<Vec<Token>>,
+    current_block: &mut Vec<Token>,
+    previous_block: &mut Vec<Token>,
+    line: &[Token],
+) {
+    if let Some(previous_line_start) = previous_block.first() {
+        if *previous_line_start == Token::Punctuation(String::from("*"))
+            && previous_block.get(1) == Some(&Token::Whitespace)
+        {
+            attach_to_previous_block(blocks, previous_block, line, Some(Token::Newline));
+        } else {
+            current_block.extend_from_slice(line);
         }
     } else {
         current_block.extend_from_slice(line);

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -760,6 +760,172 @@ mod block {
     }
 
     #[test]
+    fn unordered_list_using_asterisks() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(&group_lines_to_blocks(vec![
+                tokenize("* Item 1"),
+                tokenize("* Item 2")
+            ])),
+            vec![UnorderedList {
+                items: vec![
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 1")
+                            }]
+                        }
+                    },
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 2")
+                            }]
+                        }
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn unordered_nested_list_with_asterisks() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(&group_lines_to_blocks(vec![
+                tokenize("* Item 1"),
+                tokenize("    * Nested Item 1.1"),
+                tokenize("    * Nested Item 1.2"),
+                tokenize("* Item 2")
+            ])),
+            vec![UnorderedList {
+                items: vec![
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 1")
+                            }]
+                        }
+                    },
+                    MdListItem {
+                        content: UnorderedList {
+                            items: vec![
+                                MdListItem {
+                                    content: Paragraph {
+                                        content: vec![Text {
+                                            content: String::from("Nested Item 1.1")
+                                        }]
+                                    }
+                                },
+                                MdListItem {
+                                    content: Paragraph {
+                                        content: vec![Text {
+                                            content: String::from("Nested Item 1.2")
+                                        }]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 2")
+                            }]
+                        }
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn unordered_list_with_mixed_delimiters() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(&group_lines_to_blocks(vec![
+                tokenize("- Item 1"),
+                tokenize("* New List")
+            ])),
+            vec![
+                UnorderedList {
+                    items: vec![MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 1")
+                            }]
+                        }
+                    }]
+                },
+                UnorderedList {
+                    items: vec![MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("New List")
+                            }]
+                        }
+                    }]
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn unordered_nested_list_with_mixed_delimiters() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(&group_lines_to_blocks(vec![
+                tokenize("- Item 1"),
+                tokenize("    * Nested Item 1.1"),
+                tokenize("    - Nested Item 1.2"),
+                tokenize("* Item 2")
+            ])),
+            vec![
+                UnorderedList {
+                    items: vec![
+                        MdListItem {
+                            content: Paragraph {
+                                content: vec![Text {
+                                    content: String::from("Item 1")
+                                }]
+                            }
+                        },
+                        MdListItem {
+                            content: UnorderedList {
+                                items: vec![
+                                    MdListItem {
+                                        content: Paragraph {
+                                            content: vec![Text {
+                                                content: String::from("Nested Item 1.1")
+                                            }]
+                                        }
+                                    },
+                                    MdListItem {
+                                        content: Paragraph {
+                                            content: vec![Text {
+                                                content: String::from("Nested Item 1.2")
+                                            }]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                    ]
+                },
+                UnorderedList {
+                    items: vec![MdListItem {
+                        content: Paragraph {
+                            content: vec![Text {
+                                content: String::from("Item 2")
+                            }]
+                        }
+                    }]
+                }
+            ]
+        );
+    }
+
+    #[test]
     fn unordered_list_with_inlines() {
         init_test_config();
         assert_eq!(
@@ -1879,6 +2045,21 @@ mod html_generation {
         }
 
         #[test]
+        fn unordered_list_using_asterisks() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(&group_lines_to_blocks(vec![
+                    tokenize("* Item 1"),
+                    tokenize("* Item 2")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<ul>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<li>\n\t\t<p>Item 2</p>\n\t</li>\n</ul>"
+            );
+        }
+
+        #[test]
         fn unordered_list_with_nested_items() {
             init_test_config();
             assert_eq!(
@@ -1892,6 +2073,57 @@ mod html_generation {
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
                 "<ul>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ul>\n\t\t<li>\n\t\t\t<p>Nested Item 1.1</p>\n\t\t</li>\n\t\t<li>\n\t\t\t<p>Nested Item 1.2</p>\n\t\t</li>\n\t</ul><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ul>"
+            );
+        }
+
+        #[test]
+        fn unordered_nested_list_with_asterisks() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(&group_lines_to_blocks(vec![
+                    tokenize("* Item 1"),
+                    tokenize("    * Nested Item 1.1"),
+                    tokenize("    * Nested Item 1.2"),
+                    tokenize("* Item 2")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<ul>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ul>\n\t\t<li>\n\t\t\t<p>Nested Item 1.1</p>\n\t\t</li>\n\t\t<li>\n\t\t\t<p>Nested Item 1.2</p>\n\t\t</li>\n\t</ul><li>\n\t\t<p>Item 2</p>\n\t</li>\n</ul>"
+            );
+        }
+
+        #[test]
+        fn unordered_list_with_mixed_delimiters() {
+            // Will be two separate lists
+            init_test_config();
+            assert_eq!(
+                parse_blocks(&group_lines_to_blocks(vec![
+                    tokenize("- Item 1"),
+                    tokenize("* Item 2"),
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<ul>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n</ul><ul>\n\t<li>\n\t\t<p>Item 2</p>\n\t</li>\n</ul>"
+            );
+        }
+
+        #[test]
+        fn unordered_nested_list_with_mixed_delimiters() {
+            // Will be two separate lists
+            init_test_config();
+            assert_eq!(
+                parse_blocks(&group_lines_to_blocks(vec![
+                    tokenize("- Item 1"),
+                    tokenize("    * Nested Item 1.1"),
+                    tokenize("    - Nested Item 1.2"),
+                    tokenize("* Item 2")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<ul>\n\t<li>\n\t\t<p>Item 1</p>\n\t</li>\n\t<ul>\n\t\t<li>\n\t\t\t<p>Nested Item 1.1</p>\n\t\t</li>\n\t\t<li>\n\t\t\t<p>Nested Item 1.2</p>\n\t\t</li>\n\t</ul>\n</ul><ul>\n\t<li>\n\t\t<p>Item 2</p>\n\t</li>\n</ul>"
             );
         }
 


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for bulleted lists (list elements starting with asterisks).

## More Details

<!-- Describe the changes made in this pull request -->

- `*` characters are now tokenized differently depending on the context surrounding them
  - If they are followed by a space and are at the start of the line, or preceded by tabs and followed by a space, then they are considered valid unordered list markers
- Lines starting with asterisks are now grouped together, and will create their own lists if following lines starting with dashes
  - Note that this is not the case for tabbed lines; tabbed lines, as per the Commonmark spec, are allowed to group with lists before it. So, for example, if the line starting the list begins with a dash, and the second line starts with a tab and then an asterisk, it will be grouped with the first line, despite their markers being different.

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- There are now tests for lists using asterisks, as well as tests for mixed markers and nested lists with mixed markers