### PR TITLE
Add flag to exclude files

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can also use the following CLI arguments to customize the behavior of Mark-r
 - `-n --num_threads <NUM_THREADS>`: Specify the number of threads to use (default: 4).
 - `-r, --recursive`: Recursively parse all Markdown files in the specified directory and its subdirectories. (default: false if not present)
 - `-v, --verbose`: Enable verbose output, which will print additional information while the program is running.
+- `-e, --exclude <EXCLUDED_FILES>`: Exclude specific files or directories from being parsed. You can specify multiple files or directories by separating them with spaces.
 - `-O, --open`: Open the generated index.html in the default web browser.
 - `-h, --help`: Display help information.
 - `-V, --version`: Display the version of Mark-rs.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ You can also use the following CLI arguments to customize the behavior of Mark-r
 - `-h, --help`: Display help information.
 - `-V, --version`: Display the version of Mark-rs.
 
+#### Note about `--exclude`
+
+Make sure to not put the list of excluded files just before the input directory, as then the input directory will be considered as an excluded file, leading to an error about the `<INPUT_DIR>` not being provided. Instead, put the `--exclude` option either after the input directory or have another flag between the exclude option and the input directory, like so:
+
+```bash
+markrs -o output/ -c config.toml -e file1.md dir_1 -r -O ./input # Notice that `-r` and `-O` are separate `-e` and the input directory
+```
+
+Or like so:
+
+```bash
+markrs -o output/ -c config.toml -r -O ./input --exclude file1.md dir_1 # Notice that `--exclude` is after the input directory
+```
+
 ## Configuration
 
 You can customize Mark-rs's behavior by specifying a config file to use. If a config file is not specified, then the default configuration directory will be checked; if no config file already exists, then the default `config.toml` file will be written.

--- a/src/io.rs
+++ b/src/io.rs
@@ -26,6 +26,7 @@ use crate::html_generator::generate_default_css;
 pub fn read_input_dir(
     input_dir: &str,
     run_recursively: &bool,
+    excluded_entries: &[String],
 ) -> Result<Vec<(String, String)>, io::Error> {
     if *run_recursively {
         // If recursive, visit all subdirectories
@@ -88,6 +89,7 @@ fn visit_dir(
     dir: &Path,
     base: &Path,
     file_contents: &mut Vec<(String, String)>,
+    excluded_entries: &[String],
 ) -> Result<(), std::io::Error> {
     for entry in read_dir(dir)? {
         let entry = entry?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn run() -> Result<(), Error> {
 
     init_config(config_path)?;
     let config = CONFIG.get().unwrap();
-    let file_contents = read_input_dir(input_dir, run_recursively)?;
+    let file_contents = read_input_dir(input_dir, run_recursively, &cli.exclude)?;
     let mut file_names: Vec<String> = Vec::with_capacity(file_contents.len());
 
     let thread_pool = ThreadPool::build(num_threads).map_err(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,8 @@ struct Cli {
         help = "Open the generated index.html in the default web browser."
     )]
     open: bool,
+    #[arg(short, long, default_value = "", num_args = 0.., help = "Exclude files or directories from the input directory. Can be specified multiple times, or as a space-separated list.")]
+    exclude: Vec<String>,
 }
 
 fn main() -> Result<(), Error> {


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added a flag to allow users to exclude files and directories.

## More Details

<!-- Describe the changes made in this pull request -->

### CLI
- There's a new `-e` / `--exclude` flag that accepts a list of space-separated files and directories
  - i.e. `-e test my_file.md another_file.md` would exclude the entire "test" subdirectory and the "my_file.md" and "another_file.md" files

#### Note about the CLI update
There is a potential issue with the `-e` flag; it can't directly precede the input directory, as it will assume the input directory is part of the `-e` flag, and will panic. 

To work around this, the user can either:
1. Place a flag between `-e` and the input directory
  a. i.e. `markrs -e test_dir -o my_output input_dir`
2. Placing the `-e` flag _after_ the input directory
  a. i.e. `markrs -o my_output input_dir -e test_dir`