### PR TITLE
Add watch flag/hot-reloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,16 +81,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -183,6 +210,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +264,22 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -253,6 +330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,12 +368,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -298,6 +411,70 @@ checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -312,10 +489,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
 
 [[package]]
 name = "heck"
@@ -332,6 +552,74 @@ dependencies = [
  "log",
  "markup5ever",
  "match_token",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -452,6 +740,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +828,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,8 +859,9 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -571,17 +900,21 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "mark-rs"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "ammonia",
  "clap",
  "dirs",
  "env_logger",
+ "futures-util",
  "log",
+ "notify",
  "serde",
+ "tokio",
  "toml_edit",
  "unicode-segmentation",
  "unicode_categories",
+ "warp",
  "webbrowser",
 ]
 
@@ -614,6 +947,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +1014,25 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "objc2"
@@ -646,7 +1055,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "objc2",
 ]
 
@@ -750,6 +1159,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +1212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -803,6 +1253,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -811,6 +1273,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -818,7 +1283,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -862,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1340,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -897,6 +1374,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,16 +1395,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1038,6 +1591,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio 1.1.0",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.1",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1681,69 @@ name = "toml_writer"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -1124,6 +1793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1806,44 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1244,6 +1957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,11 +1973,47 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1278,6 +2033,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -1285,11 +2055,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1300,9 +2087,21 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1312,9 +2111,21 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1324,15 +2135,33 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1342,9 +2171,21 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1354,9 +2195,21 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1366,9 +2219,21 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1378,9 +2243,21 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1419,6 +2296,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "A Markdown parser and Static Site Generator"
 edition = "2024"
 name = "mark-rs"
-version = "1.3.3"
+version = "1.3.4"
 license = "MIT"
 keywords = ["markdown", "cli", "ssg", "static_site", "notes"]
 repository = "https://github.com/zliel/Mark-rs"
@@ -19,6 +19,10 @@ toml_edit = { version = "0.23.2", features = ["serde"] }
 unicode-segmentation = "1.12.0"
 unicode_categories = "0.1.1"
 webbrowser = "1.0.5"
+notify = "6.1.1"
+warp = "0.3"
+tokio = { version = "1.0", features = ["full"] }
+futures-util = "0.3"
 
 [[bin]]
 name = "markrs"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can also use the following CLI arguments to customize the behavior of Mark-r
 - `-v, --verbose`: Enable verbose output, which will print additional information while the program is running.
 - `-e, --exclude <EXCLUDED_FILES>`: Exclude specific files or directories from being parsed. You can specify multiple files or directories by separating them with spaces.
 - `-O, --open`: Open the generated index.html in the default web browser.
+- `-w, --watch`: Watch the input directory for changes and automatically re-parse the Markdown files when changes are detected.
 - `-h, --help`: Display help information.
 - `-V, --version`: Display the version of Mark-rs.
 
@@ -112,7 +113,7 @@ You can also use the following CLI arguments to customize the behavior of Mark-r
 Make sure to not put the list of excluded files just before the input directory, as then the input directory will be considered as an excluded file, leading to an error about the `<INPUT_DIR>` not being provided. Instead, put the `--exclude` option either after the input directory or have another flag between the exclude option and the input directory, like so:
 
 ```bash
-markrs -o output/ -c config.toml -e file1.md dir_1 -r -O ./input # Notice that `-r` and `-O` are separate `-e` and the input directory
+markrs -o output/ -c config.toml -e file1.md dir_1 -r -O ./input # Notice that `-r` and `-O` separate `-e` and the input directory
 ```
 
 Or like so:

--- a/src/html_generator.rs
+++ b/src/html_generator.rs
@@ -25,6 +25,7 @@ pub fn generate_html(
     output_dir: &str,
     input_dir: &str,
     html_rel_path: &str,
+    is_watching: bool,
 ) -> String {
     let mut html_output = String::new();
     let config = CONFIG.get().unwrap();
@@ -85,6 +86,40 @@ pub fn generate_html(
         body.push_str("\n\t\t<script src=\"https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/plugins/show-language/prism-show-language.min.js\" integrity=\"sha512-d1t+YumgzdIHUL78me4B9NzNTu9Lcj6RdGVbdiFDlxRV9JTN9s+iBQRhUqLRq5xtWUp1AD+cW2sN2OlST716fw==\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>");
     }
 
+    if is_watching {
+        body.push_str(
+            r#"
+        <script>
+            (function() {
+                var maxRetries = 5;
+                var retryCount = parseInt(sessionStorage.getItem("wsRetries") || "0");
+                if (retryCount >= maxRetries) {
+                    console.warn("[LiveReload] Server offline. Refresh manually when ready.");
+                    return;
+                }
+                var ws = new WebSocket("ws://localhost:3030/ws");
+                ws.onopen = function() { sessionStorage.setItem("wsRetries", "0"); };
+                ws.onmessage = function(e) {
+                    if (e.data === "reload") {
+                        sessionStorage.setItem("wsRetries", "0");
+                        location.reload();
+                    }
+                };
+                ws.onclose = function() {
+                    retryCount++;
+                    sessionStorage.setItem("wsRetries", retryCount.toString());
+                    if (retryCount < maxRetries) {
+                        setTimeout(function() { location.reload(); }, 1000);
+                    } else {
+                        console.warn("[LiveReload] Server offline. Refresh manually when ready.");
+                    }
+                };
+            })();
+        </script>
+        "#,
+        );
+    }
+
     body.push_str("\n\t</body>\n");
 
     html_output.push_str(&head);
@@ -101,7 +136,7 @@ pub fn generate_html(
 ///
 /// # Returns
 /// Returns a `String` containing the generated HTML for the index page.
-pub fn generate_index(file_names: &[String]) -> String {
+pub fn generate_index(file_names: &[String], is_watching: bool) -> String {
     let mut html_output = String::new();
 
     let head = generate_head("index", "index.html", CONFIG.get().unwrap());
@@ -119,7 +154,43 @@ pub fn generate_index(file_names: &[String]) -> String {
         ));
     });
 
-    body.push_str("\n</div>\n\t</body>\n");
+    body.push_str("\n</div>\n");
+
+    if is_watching {
+        body.push_str(
+            r#"
+        <script>
+            (function() {
+                var maxRetries = 5;
+                var retryCount = parseInt(sessionStorage.getItem("wsRetries") || "0");
+                if (retryCount >= maxRetries) {
+                    console.warn("[LiveReload] Server offline. Refresh manually when ready.");
+                    return;
+                }
+                var ws = new WebSocket("ws://localhost:3030/ws");
+                ws.onopen = function() { sessionStorage.setItem("wsRetries", "0"); };
+                ws.onmessage = function(e) {
+                    if (e.data === "reload") {
+                        sessionStorage.setItem("wsRetries", "0");
+                        location.reload();
+                    }
+                };
+                ws.onclose = function() {
+                    retryCount++;
+                    sessionStorage.setItem("wsRetries", retryCount.toString());
+                    if (retryCount < maxRetries) {
+                        setTimeout(function() { location.reload(); }, 1000);
+                    } else {
+                        console.warn("[LiveReload] Server offline. Refresh manually when ready.");
+                    }
+                };
+            })();
+        </script>
+        "#,
+        );
+    }
+
+    body.push_str("\t</body>\n");
 
     html_output.push_str(&head);
     html_output.push_str(&body);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,12 @@ mod parser;
 mod thread_pool;
 mod types;
 mod utils;
+mod watch;
 
 use clap::{Parser, command};
 use env_logger::Env;
 use log::{error, info};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use crate::config::{Config, init_config};
@@ -56,6 +57,19 @@ struct Cli {
     open: bool,
     #[arg(short, long, default_value = "", num_args = 0.., help = "Exclude files or directories from the input directory. Can be specified multiple times, or as a space-separated list.")]
     exclude: Vec<String>,
+    #[arg(
+        short,
+        long,
+        default_value = "false",
+        help = "Watch for changes and rebuild automatically."
+    )]
+    watch: bool,
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Open the markdown file with syntax highlighting alongside its generated HTML."
+    )]
+    preview: bool,
 }
 
 fn main() -> Result<(), Error> {
@@ -72,13 +86,9 @@ fn main() -> Result<(), Error> {
 }
 
 fn run() -> Result<(), Error> {
-    let cli = Cli::parse();
-    let input_dir = &cli.input_dir;
-    let config_path = &cli.config;
-    let run_recursively = &cli.recursive;
-    let num_threads = cli.num_threads;
+    let cli = Arc::new(Cli::parse());
 
-    // Setup
+    // Setup logging once
     let env = if cli.verbose {
         Env::default().default_filter_or("info")
     } else {
@@ -86,21 +96,160 @@ fn run() -> Result<(), Error> {
     };
     env_logger::Builder::from_env(env).init();
 
-    init_config(config_path)?;
+    // Create thread pool once
+    let thread_pool = Arc::new(ThreadPool::build(cli.num_threads).map_err(|e| {
+        error!("Failed to create thread pool: {e}");
+        e
+    })?);
+
+    if cli.watch {
+        let cli_clone = Arc::clone(&cli);
+        let input_dir = cli.input_dir.clone();
+        let output_dir = cli.output_dir.clone();
+        let pool_clone = Arc::clone(&thread_pool);
+
+        let cli_clone2 = Arc::clone(&cli);
+        let input_dir_clone = cli.input_dir.clone();
+
+        if let Err(e) = watch::start_watch_mode(
+            input_dir,
+            output_dir,
+            // Full build callback (for initial build)
+            move || match build(Arc::clone(&cli_clone), &pool_clone) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(Box::new(e)),
+            },
+            // Incremental build callback (for file changes)
+            move |changed_paths: &[PathBuf]| {
+                let cli = Arc::clone(&cli_clone2);
+                let input_base = Path::new(&input_dir_clone);
+                let mut needs_index_rebuild = false;
+                let mut processed_files: Vec<String> = Vec::new();
+
+                for changed_path in changed_paths {
+                    // Only process markdown files
+                    if !changed_path.extension().is_some_and(|ext| ext == "md") {
+                        info!("Skipping non-markdown file: {:?}", changed_path);
+                        continue;
+                    }
+
+                    // Read the file content
+                    let file_content = match std::fs::read_to_string(changed_path) {
+                        Ok(content) => content,
+                        Err(e) => {
+                            error!("Failed to read file {:?}: {}", changed_path, e);
+                            continue;
+                        }
+                    };
+
+                    // Get relative path from input directory
+                    let relative_path = match changed_path.strip_prefix(input_base) {
+                        Ok(rel) => rel.to_string_lossy().to_string(),
+                        Err(_) => {
+                            // Fallback to filename if strip_prefix fails
+                            changed_path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().to_string())
+                                .unwrap_or_default()
+                        }
+                    };
+
+                    // Check if this is a new file (output HTML doesn't exist yet)
+                    let html_relative = if relative_path.ends_with(".md") {
+                        relative_path.trim_end_matches(".md").to_string() + ".html"
+                    } else {
+                        relative_path.clone() + ".html"
+                    };
+                    let output_path = Path::new(&cli.output_dir).join(&html_relative);
+                    if !output_path.exists() {
+                        info!("New file detected: {}", relative_path);
+                        needs_index_rebuild = true;
+                    }
+
+                    processed_files.push(relative_path.clone());
+                    info!("Rebuilding: {}", relative_path);
+
+                    if let Err(e) =
+                        generate_static_site(Arc::clone(&cli), &relative_path, &file_content)
+                    {
+                        error!("Failed to rebuild {:?}: {}", changed_path, e);
+                    }
+                }
+
+                // Regenerate index if new files were added
+                if needs_index_rebuild {
+                    info!("Regenerating index.html for new files...");
+                    // Get all markdown files in input directory
+                    if let Ok(all_files) =
+                        read_input_dir(&cli.input_dir, &cli.recursive, &cli.exclude)
+                    {
+                        let file_names: Vec<String> =
+                            all_files.iter().map(|(name, _)| name.clone()).collect();
+                        let index_html = generate_index(&file_names, cli.watch);
+                        if let Err(e) =
+                            write_html_to_file(&index_html, &cli.output_dir, "index.html")
+                        {
+                            error!("Failed to update index.html: {}", e);
+                        } else {
+                            info!("Index updated with {} files.", file_names.len());
+                        }
+                    }
+                }
+
+                Ok(())
+            },
+        ) {
+            error!("Watch mode failed: {}", e);
+            std::process::exit(1);
+        }
+    } else {
+        build(cli, &thread_pool)?;
+        // Wait for all threads to finish in non-watch mode
+        // Note: join_all consumes the pool. We need to unwrap the Arc.
+        if let Ok(pool) = Arc::try_unwrap(thread_pool) {
+            pool.join_all();
+        } else {
+            error!("Failed to unwrap thread pool for cleanup");
+        }
+    }
+
+    Ok(())
+}
+
+fn build(cli: Arc<Cli>, thread_pool: &ThreadPool) -> Result<(), Error> {
+    let input_dir = &cli.input_dir;
+    let config_path = &cli.config;
+    let run_recursively = &cli.recursive;
+
+    // Use try_init_config to avoid double initialization error in watch mode
+    if CONFIG.get().is_none() {
+        init_config(config_path)?;
+    }
+
     let config = CONFIG.get().unwrap();
     let file_contents = read_input_dir(input_dir, run_recursively, &cli.exclude)?;
     let mut file_names: Vec<String> = Vec::with_capacity(file_contents.len());
 
-    let thread_pool = ThreadPool::build(num_threads).map_err(|e| {
-        error!("Failed to create thread pool: {e}");
-        e
-    })?;
-    let cli = Arc::new(cli);
+    // Ensure output directory exists
+    if let Err(e) = std::fs::create_dir_all(&cli.output_dir) {
+        error!(
+            "Failed to create output directory {}: {}",
+            cli.output_dir, e
+        );
+        return Err(e.into());
+    }
+
+    // Synchronization channel
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut task_count = 0;
 
     for (file_path, file_content) in file_contents {
         info!("Generating HTML for file: {}", file_path);
 
         file_names.push(file_path.clone());
+
+        let tx = tx.clone();
+        task_count += 1;
 
         thread_pool
             .execute({
@@ -109,6 +258,7 @@ fn run() -> Result<(), Error> {
                     generate_static_site(cli, &file_path, &file_content).unwrap_or_else(|e| {
                         error!("Failed to generate HTML for {file_path}: {e}");
                     });
+                    let _ = tx.send(());
                 }
             })
             .map_err(|e| {
@@ -117,16 +267,20 @@ fn run() -> Result<(), Error> {
             })?;
     }
 
+    // Index Generation
+    let tx_index = tx.clone();
+    task_count += 1;
     thread_pool
         .execute({
             let cli = Arc::clone(&cli);
             move || {
-                let index_html = generate_index(&file_names);
+                let index_html = generate_index(&file_names, cli.watch);
                 write_html_to_file(&index_html, &cli.output_dir, "index.html").unwrap_or_else(
                     |e| {
                         error!("Failed to write index.html: {e}");
                     },
                 );
+                let _ = tx_index.send(());
             }
         })
         .map_err(|e| {
@@ -135,6 +289,8 @@ fn run() -> Result<(), Error> {
         })?;
 
     let css_file = &config.html.css_file;
+    let tx_css = tx.clone();
+    task_count += 1;
     if css_file != "default" && !css_file.is_empty() {
         info!("Using custom CSS file: {}", css_file);
         thread_pool
@@ -144,6 +300,7 @@ fn run() -> Result<(), Error> {
                     copy_css_to_output_dir(css_file, &cli.output_dir).unwrap_or_else(|e| {
                         error!("Failed to copy CSS file: {e}");
                     });
+                    let _ = tx_css.send(());
                 }
             })
             .map_err(|e| {
@@ -160,6 +317,7 @@ fn run() -> Result<(), Error> {
                     write_default_css_file(&cli.output_dir).unwrap_or_else(|e| {
                         error!("Failed to write default CSS file: {e}");
                     });
+                    let _ = tx_css.send(());
                 }
             })
             .map_err(|e| {
@@ -171,6 +329,8 @@ fn run() -> Result<(), Error> {
     let favicon_path = &config.html.favicon_file;
     if !favicon_path.is_empty() {
         info!("Copying favicon from: {}", favicon_path);
+        let tx_fav = tx.clone();
+        task_count += 1;
         thread_pool
             .execute({
                 let cli = Arc::clone(&cli);
@@ -178,6 +338,7 @@ fn run() -> Result<(), Error> {
                     copy_favicon_to_output_dir(favicon_path, &cli.output_dir).unwrap_or_else(|e| {
                         error!("Failed to copy favicon: {e}");
                     });
+                    let _ = tx_fav.send(());
                 }
             })
             .map_err(|e| {
@@ -188,9 +349,19 @@ fn run() -> Result<(), Error> {
         info!("No favicon specified in config.");
     }
 
-    thread_pool.join_all();
+    // Drop original sender to prevent hanging
+    drop(tx);
 
-    if cli.open {
+    // Wait for all tasks to complete
+    for _ in 0..task_count {
+        if let Err(e) = rx.recv() {
+            error!("Failed to receive completion signal: {}", e);
+        }
+    }
+
+    // In watch mode, we rely on the server to serve files, so we might not need to open the browser via cli.
+    // But the user might still want to open it initially.
+    if cli.open && !cli.watch {
         let index_path = Path::new(&cli.output_dir).join("index.html");
         if index_path.exists() {
             if let Err(e) = webbrowser::open(&index_path.to_string_lossy()) {
@@ -205,6 +376,7 @@ fn run() -> Result<(), Error> {
             );
         }
     }
+    // If watching, the watch loop might print the URL.
 
     Ok(())
 }
@@ -227,6 +399,7 @@ fn generate_static_site(cli: Arc<Cli>, file_path: &str, file_contents: &str) -> 
         &cli.output_dir,
         &cli.input_dir,
         file_path,
+        cli.watch,
     );
 
     let html_relative_path = if file_path.ends_with(".md") {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,239 @@
+use log::{error, info};
+use notify::event::EventKind;
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::sync::broadcast;
+use warp::Filter;
+
+/// Starts the watch mode, which includes:
+/// 1. A file watcher that triggers a rebuild on changes.
+/// 2. A local web server that serves the output directory.
+/// 3. A WebSocket server that sends reload signals to the browser.
+///
+/// # Arguments
+/// * `input_dir` - Directory to watch for changes
+/// * `output_dir` - Directory where output is served from
+/// * `full_build_fn` - Called for initial build
+/// * `incremental_build_fn` - Called with changed file paths for incremental rebuilds
+pub fn start_watch_mode<F, I>(
+    input_dir: String,
+    output_dir: String,
+    full_build_fn: F,
+    incremental_build_fn: I,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    F: Fn() -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync + 'static,
+    I: Fn(&[PathBuf]) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+        + Send
+        + Sync
+        + 'static,
+{
+    info!("Starting watch mode...");
+    info!("Serving at http://localhost:3030");
+
+    // Create a Tokio runtime for the async server and watcher components
+    let rt = Runtime::new()?;
+
+    rt.block_on(async {
+        let (tx, _rx) = broadcast::channel::<String>(16);
+
+        // Channel for file watcher events -> debouncer loop (now passes paths)
+        let (notify_tx, mut notify_rx) = tokio::sync::mpsc::unbounded_channel::<PathBuf>();
+
+        // Shared set to collect changed paths during debounce window
+        let pending_paths: Arc<Mutex<HashSet<PathBuf>>> = Arc::new(Mutex::new(HashSet::new()));
+        let pending_paths_watcher = Arc::clone(&pending_paths);
+
+        // 1. Setup File Watcher
+        let full_build_fn = Arc::new(full_build_fn);
+        let incremental_build_fn = Arc::new(incremental_build_fn);
+        let input_path = input_dir.clone();
+
+        // Run initial full build
+        if let Err(e) = full_build_fn() {
+            error!("Initial build failed: {}", e);
+        }
+
+        let mut watcher = RecommendedWatcher::new(
+            move |res: Result<Event, notify::Error>| {
+                match res {
+                    Ok(event) => {
+                        // Filter to only relevant events: Create, Modify (data changes)
+                        // Ignore: Access, Remove, metadata-only changes
+                        let dominated = matches!(
+                            event.kind,
+                            EventKind::Create(_)
+                                | EventKind::Modify(notify::event::ModifyKind::Data(_))
+                                | EventKind::Modify(notify::event::ModifyKind::Any)
+                        );
+
+                        if dominated {
+                            for path in event.paths {
+                                info!("File changed: {:?}", path);
+                                // Add to pending set and notify
+                                if let Ok(mut paths) = pending_paths_watcher.lock() {
+                                    paths.insert(path.clone());
+                                }
+                                let _ = notify_tx.send(path);
+                            }
+                        }
+                    }
+                    Err(e) => error!("Watch error: {:?}", e),
+                }
+            },
+            Config::default(), // Use native watcher (no poll interval for faster events on Windows)
+        )?;
+
+        watcher.watch(Path::new(&input_path), RecursiveMode::Recursive)?;
+
+        // Spawn logic to handle debounced rebuilding
+        let builder_tx = tx.clone();
+        let incremental_build_fn_clone = Arc::clone(&incremental_build_fn);
+        let pending_paths_builder = Arc::clone(&pending_paths);
+        tokio::spawn(async move {
+            loop {
+                // Wait for the first notification
+                if notify_rx.recv().await.is_none() {
+                    break;
+                }
+
+                // Debounce: Wait a short buffer for more events to trickle in (e.g., "save all")
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                // Drain any pending events that happened during the wait
+                while notify_rx.try_recv().is_ok() {}
+
+                // Collect and clear pending paths
+                let changed_paths: Vec<PathBuf> = {
+                    let mut paths = pending_paths_builder.lock().unwrap();
+                    let collected: Vec<PathBuf> = paths.drain().collect();
+                    collected
+                };
+
+                if changed_paths.is_empty() {
+                    continue;
+                }
+
+                info!("Rebuilding {} file(s)...", changed_paths.len());
+
+                // Offload blocking build to a dedicated thread to avoid starving the async runtime
+                let build_fn = Arc::clone(&incremental_build_fn_clone);
+                let result = tokio::task::spawn_blocking(move || build_fn(&changed_paths)).await;
+
+                match result {
+                    Ok(Ok(_)) => {
+                        info!("Rebuild successful.");
+                        // Send reload signal
+                        let receiver_count = builder_tx.receiver_count();
+                        info!(
+                            "Broadcasting reload to {} connected clients...",
+                            receiver_count
+                        );
+                        match builder_tx.send("reload".to_string()) {
+                            Ok(n) => info!("Reload signal sent to {} receivers", n),
+                            Err(e) => error!("Failed to send reload signal: {:?}", e),
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        error!("Rebuild failed: {}", e);
+                    }
+                    Err(e) => {
+                        error!("Join error: {}", e);
+                    }
+                }
+            }
+        });
+
+        // 2. Setup Web Server and WebSockets
+
+        // Serve static files with no-cache headers to ensure browser sees updates
+        let static_files = warp::fs::dir(output_dir.clone()).map(|reply| {
+            warp::reply::with_header(reply, "Cache-Control", "no-store, must-revalidate")
+        });
+
+        // WebSocket route
+        let ws_route = warp::path("ws")
+            .and(warp::ws())
+            .and(warp::any().map(move || tx.clone()))
+            .map(|ws: warp::ws::Ws, tx: broadcast::Sender<String>| {
+                ws.on_upgrade(move |socket| handle_ws_client(socket, tx))
+            });
+
+        // Combine routes
+        let routes = ws_route.or(static_files);
+
+        warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+
+        Ok(())
+    })
+}
+
+async fn handle_ws_client(ws: warp::ws::WebSocket, tx: broadcast::Sender<String>) {
+    use futures_util::{SinkExt, StreamExt};
+
+    info!(
+        "WebSocket client connected. Total receivers: {}",
+        tx.receiver_count()
+    );
+    let mut rx = tx.subscribe();
+    info!(
+        "Subscribed to broadcast channel. Now {} receivers.",
+        tx.receiver_count()
+    );
+
+    // Split WebSocket into sender and receiver
+    let (mut ws_tx, mut ws_rx) = ws.split();
+
+    loop {
+        tokio::select! {
+            // Handle broadcast messages (reload signals)
+            broadcast_result = rx.recv() => {
+                match broadcast_result {
+                    Ok(msg) if msg == "reload" => {
+                        info!("Sending reload signal to browser...");
+                        if let Err(e) = ws_tx.send(warp::ws::Message::text("reload")).await {
+                            error!("Failed to send reload to WebSocket: {:?}", e);
+                            break;
+                        }
+                        // Flush immediately for fastest delivery
+                        if let Err(e) = ws_tx.flush().await {
+                            error!("Failed to flush WebSocket: {:?}", e);
+                            break;
+                        }
+                        info!("Reload signal delivered to browser.");
+                    }
+                    Ok(_) => {} // Ignore other messages
+                    Err(e) => {
+                        error!("Broadcast channel error: {:?}", e);
+                        break;
+                    }
+                }
+            }
+            // Handle incoming WebSocket messages (keep connection alive)
+            ws_msg = ws_rx.next() => {
+                match ws_msg {
+                    Some(Ok(msg)) => {
+                        // Just acknowledge we received something - keeps connection alive
+                        if msg.is_close() {
+                            info!("WebSocket client disconnected.");
+                            break;
+                        }
+                        // Ping/pong is handled automatically by warp
+                    }
+                    Some(Err(e)) => {
+                        error!("WebSocket receive error: {:?}", e);
+                        break;
+                    }
+                    None => {
+                        info!("WebSocket stream ended.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added a `-w` flag that watches directories for changes, allowing hot-reloading when changes are made to the input files. 

## More Details

<!-- Describe the changes made in this pull request -->

- There are new `-w`/`--watch` flags that watch the input directory
- When watching, a script tag is added to the output html files to retry loading the file a few times if the hot-reload fails
- When changes are saved, the new file is regenerated and a signal is sent out, which gets picked up by the currently loaded html file and if it was the one regenerated, the page reloads

## New Dependencies (if applicable)

<!-- List any new dependencies added in this pull request -->

- Warp
- Tokio
- Notify
- Futures-util

## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->
